### PR TITLE
Fix package references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,12 @@
 <Project>
   <PropertyGroup>
     <MicrosoftSqlServerCompactPackageVersion>4.08876.1</MicrosoftSqlServerCompactPackageVersion>
-    <MicrosoftVisualStudioComponentModelHostPackageVersion>17.0.32-g9d6b2c6f26</MicrosoftVisualStudioComponentModelHostPackageVersion>
+    <MicrosoftVisualStudioComponentModelHostPackageVersion>17.0.77-g1cdf89c995</MicrosoftVisualStudioComponentModelHostPackageVersion>
     <MicrosoftVisualStudioExtensibilityHostingPackageVersion>17.0.32-g9d6b2c6f26</MicrosoftVisualStudioExtensibilityHostingPackageVersion>
     <MicrosoftVisualStudioPackageCurrent>17.0.0-previews-2-31405-002</MicrosoftVisualStudioPackageCurrent>
     <MicrosoftVisualStudioDataCorePackageVersion>$(MicrosoftVisualStudioPackageCurrent)</MicrosoftVisualStudioDataCorePackageVersion>
     <MicrosoftVisualStudioDataDesignCommonPackageVersion>$(MicrosoftVisualStudioPackageCurrent)</MicrosoftVisualStudioDataDesignCommonPackageVersion>
-    <MicrosoftVisualStudioModelingPackageVersion>$(MicrosoftVisualStudioPackageCurrent)</MicrosoftVisualStudioModelingPackageVersion>
+    <MicrosoftVisualStudioModelingPackageVersion>17.0.0-previews-2-31415-505</MicrosoftVisualStudioModelingPackageVersion>
     <MicrosoftVisualStudioInteropPackageVersion>$(MicrosoftVisualStudioPackageCurrent)</MicrosoftVisualStudioInteropPackageVersion>
     <MicrosoftVisualStudioTemplateWizardInterfacePackageVersion>$(MicrosoftVisualStudioPackageCurrent)</MicrosoftVisualStudioTemplateWizardInterfacePackageVersion>
     <MicrosoftVisualStudioTextTemplatingInterfaces100PackageVersion>$(MicrosoftVisualStudioPackageCurrent)</MicrosoftVisualStudioTextTemplatingInterfaces100PackageVersion>

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -71,8 +71,7 @@ steps:
 
 
 
-- task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@2
-
+- task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@3
   displayName: 'Install Localization Plugin'
 
 

--- a/src/EFTools/EntityDesignBootstrapPackage/EntityDesignBootstrapPackage.csproj
+++ b/src/EFTools/EntityDesignBootstrapPackage/EntityDesignBootstrapPackage.csproj
@@ -61,6 +61,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioPackageCurrent)" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingPackageVersion)" />
+    <!-- Reference just to fix ambiguous warning -->
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationPackageVersion)" />
 
     <Reference Include="System" />

--- a/src/EFTools/EntityDesignBootstrapPackage/EntityDesignBootstrapPackage.csproj
+++ b/src/EFTools/EntityDesignBootstrapPackage/EntityDesignBootstrapPackage.csproj
@@ -61,6 +61,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioPackageCurrent)" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" Version="$(MicrosoftVisualStudioInteropPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingPackageVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationPackageVersion)" />
 
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />

--- a/src/EFTools/XmlCore/XmlCore.csproj
+++ b/src/EFTools/XmlCore/XmlCore.csproj
@@ -60,6 +60,7 @@
     <Reference Include="UIAutomationProvider" />
     <Reference Include="WindowsBase" />
 
+    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioPackageCurrent)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/EFTools/XmlCore/XmlCore.csproj
+++ b/src/EFTools/XmlCore/XmlCore.csproj
@@ -60,6 +60,7 @@
     <Reference Include="UIAutomationProvider" />
     <Reference Include="WindowsBase" />
 
+    <!-- Reference just to fix ambiguous warning -->
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioPackageCurrent)" />
   </ItemGroup>


### PR DESCRIPTION
The big part here is `MicrosoftVisualStudioModelingPackageVersion`, `MicrosoftVisualStudioComponentModelHostPackageVersion`'s update is just to avoid warnings, same with adding explicit `Microsoft.VisualStudio.Validation` references.