### PR TITLE
Fix the definition of MsgWaitForMultipleObjects and call it correctly

### DIFF
--- a/src/EFTools/DesignXmlCore/VirtualTreeGrid/DropDownControl.cs
+++ b/src/EFTools/DesignXmlCore/VirtualTreeGrid/DropDownControl.cs
@@ -2232,7 +2232,8 @@ namespace Microsoft.Data.Tools.VSXmlDesignerBase.VirtualTreeGrid
             while (Visible)
             {
                 Application.DoEvents();
-                NativeMethods.MsgWaitForMultipleObjects(1, 0, true, 250, NativeMethods.QS_ALLINPUT);
+                int result = NativeMethods.MsgWaitForMultipleObjects(0, Array.Empty<IntPtr>(), true, 250, NativeMethods.QS_ALLINPUT);
+                Debug.Assert(result != NativeMethods.WAIT_FAILED);
             }
         }
 

--- a/src/EFTools/DesignXmlCore/VisualStudio/NativeMethods.cs
+++ b/src/EFTools/DesignXmlCore/VisualStudio/NativeMethods.cs
@@ -278,6 +278,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio
             TTN_SHOW = ((0 - 520) - 1),
             TTS_NOPREFIX = 0x02,
             WA_INACTIVE = 0,
+            WAIT_FAILED = -1,
             WH_MOUSE = 7,
             WM_ACTIVATE = 0x0006,
             WM_KILLFOCUS = 0x0008,
@@ -901,9 +902,8 @@ namespace Microsoft.Data.Entity.Design.VisualStudio
         [DllImport("user32", ExactSpelling = true, CharSet = CharSet.Unicode)]
         public static extern short GetKeyState(int keyCode);
 
-        [SuppressMessage("Microsoft.Portability", "CA1901:PInvokeDeclarationsShouldBePortable")]
         [DllImport("user32", ExactSpelling = true, CharSet = CharSet.Unicode)]
-        public static extern int MsgWaitForMultipleObjects(int nCount, int pHandles, [MarshalAs(UnmanagedType.Bool)] bool fWaitAll, int dwMilliseconds, int dwWakeMask);
+        public static extern int MsgWaitForMultipleObjects(int nCount, IntPtr[] pHandles, [MarshalAs(UnmanagedType.Bool)] bool fWaitAll, int dwMilliseconds, int dwWakeMask);
 
         [DllImport("user32.dll", ExactSpelling = true, CharSet = CharSet.Unicode)]
         public static extern IntPtr GetParent(IntPtr hWnd);


### PR DESCRIPTION
The definition of MsgWaitForMultipleObjects was incorrect; pHandles should be a pointer type, but was defined as an integer. More strangely, we were passing in an array size of "1" which specified that we wanted to wait on a handle, but then passed in a null array which doesn't make sense.