### PR TITLE
Fallback Active Directory auth properties to spaced properties

### DIFF
--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageDbConfig.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageDbConfig.cs
@@ -683,8 +683,11 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
 
             string ReplaceMdsKeywords(string connectionString)
             {
-                connectionString = connectionString.Replace("Multiple Active Result Sets=", "MultipleActiveResultSets=");
-                connectionString = connectionString.Replace("Trust Server Certificate=", "TrustServerCertificate=");
+                connectionString = connectionString.Replace("Multiple Active Result Sets=", "MultipleActiveResultSets=")
+                    .Replace("Trust Server Certificate=", "TrustServerCertificate=")
+                    .Replace("Authentication=ActiveDirectoryIntegrated", "Authentication=Active Directory Integrated")
+                    .Replace("Authentication=ActiveDirectoryPassword", "Authentication=Active Directory Password")
+                    .Replace("Authentication=ActiveDirectoryInteractive", "Authentication=Active Directory Interactive");
                 return connectionString;
             }
         }

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/StoreSchemaConnectionFactory.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/StoreSchemaConnectionFactory.cs
@@ -140,8 +140,11 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb
         
         private static string ReplaceMdsKeywords(string connectionString)
         {
-            connectionString = connectionString.Replace("Multiple Active Result Sets=", "MultipleActiveResultSets=");
-            connectionString = connectionString.Replace("Trust Server Certificate=", "TrustServerCertificate=");
+            connectionString = connectionString.Replace("Multiple Active Result Sets=", "MultipleActiveResultSets=")
+                .Replace("Trust Server Certificate=", "TrustServerCertificate=")
+                .Replace("Authentication=ActiveDirectoryIntegrated", "Authentication=Active Directory Integrated")
+                .Replace("Authentication=ActiveDirectoryPassword", "Authentication=Active Directory Password")
+                .Replace("Authentication=ActiveDirectoryInteractive", "Authentication=Active Directory Interactive");
             return connectionString;
         }
 


### PR DESCRIPTION
As per https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1785212/?triage=true, we need to replace the no-space versions of Authentication connection string values with the spaced versions. We need to do this twice, in different assemblies, and unfortunately need to duplicate it.

@allisonchou 