### PR TITLE
Create a separate Yaml for PR builds

### DIFF
--- a/build/EF6Tools-VS2019-Nightly-PR.yaml
+++ b/build/EF6Tools-VS2019-Nightly-PR.yaml
@@ -46,18 +46,6 @@ steps:
     configuration: '$(BuildConfiguration)'
     msbuildArguments: '/t:AfterBuild'
 
-- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
-  displayName: 'Install Signing Plugin'
-  inputs:
-    signType: '$(SigningType)'
-
-- task: MSBuild@1
-  displayName: 'Sign Unlocalized and Localized Assemblies'
-  inputs:
-    solution: 'build\sign.proj'
-    configuration: '$(BuildConfiguration)'
-    msbuildArguments: '/t:AfterBuild'
-
 - task: NuGetCommand@2
   displayName: 'NuGet Restore Setup Inputs Packages'
   inputs:

--- a/build/EF6Tools-VS2019-Nightly-PR.yaml
+++ b/build/EF6Tools-VS2019-Nightly-PR.yaml
@@ -1,0 +1,153 @@
+pool:
+  name: VSEngSS-MicroBuild2019-1ES
+  demands:
+  - Cmd
+  - msbuild
+
+trigger:
+- main
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - '*'
+
+steps:
+- powershell: |
+   # Write your powershell commands here.
+   
+   $path = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease -all -latest -property installationPath
+   Write-Output $path
+   
+   # Use the environment variables input below to pass secret variables to this script.
+  displayName: 'Run vswhere'
+  enabled: false
+
+- task: NuGetAuthenticate@0
+  displayName: 'NuGet Authenticate'
+
+- task: NuGetToolInstaller@1
+  displayName: 'Use NuGet'
+
+- task: BatchScript@1
+  displayName: 'Run EFBuild'
+  inputs:
+    filename: '$(comspec)'
+    arguments: '/c "call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" & msbuild $(Build.Repository.LocalPath)\EFTools.msbuild /p:RunCodeAnalysis=false /p:Configuration=$(BuildConfiguration) /t:EnableSkipStrongNames;Clean;BuildDesigner -flp3:verbosity=diagnostic;logfile=$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\BuildDesigner.log -binaryLogger:logfile=$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\BuildDesigner.binlog"'
+
+- task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@3
+  displayName: 'Install Localization Plugin'
+
+- task: MSBuild@1
+  displayName: 'Localize Assemblies'
+  inputs:
+    solution: 'build\loc.proj'
+    configuration: '$(BuildConfiguration)'
+    msbuildArguments: '/t:AfterBuild'
+
+- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
+  displayName: 'Install Signing Plugin'
+  inputs:
+    signType: '$(SigningType)'
+
+- task: MSBuild@1
+  displayName: 'Sign Unlocalized and Localized Assemblies'
+  inputs:
+    solution: 'build\sign.proj'
+    configuration: '$(BuildConfiguration)'
+    msbuildArguments: '/t:AfterBuild'
+
+- task: NuGetCommand@2
+  displayName: 'NuGet Restore Setup Inputs Packages'
+  inputs:
+    command: custom
+    feedsToUse: config
+    externalFeedCredentials: 'OSSCG Feed - Microsoft approved OSS packages'
+    arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
+
+- task: BatchScript@1
+  displayName: 'Extract Setup Inputs Nuspecs'
+  inputs:
+    filename: '$(comspec)'
+    arguments: '/c "call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" & msbuild $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\GenerateMsiInputs.msbuild /p:Configuration=$(BuildConfiguration) /t:ExtractNuspecs"'
+
+- task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@4
+  displayName: 'Install Swix Plugin'
+
+- task: MSBuild@1
+  displayName: 'Build VSIX'
+  inputs:
+    solution: 'setup\swix\vs_eftools.swixproj'
+    configuration: '$(BuildConfiguration)'
+    msbuildArguments: '/t:Build'
+
+- task: CopyFiles@2
+  displayName: 'Copy VSIX'
+  inputs:
+    SourceFolder: 'bin\$(BuildConfiguration)'
+    Contents: |
+     vs_eftools.vsix
+     vs_eftools.json
+     BuildDesigner.log
+     BuildDesigner.binlog
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\SetupResults'
+
+- task: CopyFiles@2
+  displayName: 'Copy PDB and XML Files'
+  inputs:
+    SourceFolder: 'bin\$(BuildConfiguration)'
+    Contents: |
+     Microsoft.Data.*.pdb
+     Microsoft.VisualStudio.Data.*.pdb
+     Microsoft.Data.*.xml
+     Microsoft.VisualStudio.Data.*.xml
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\PdbsAndXmls'
+
+- task: CopyFiles@2
+  displayName: 'Copy BinDirContents'
+  inputs:
+    Contents: '$(Build.SourcesDirectory)\bin\**'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\BinDirContents'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish BinDirContents'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\BinDirContents'
+    ArtifactName: BinDirContents
+
+- task: CopyFiles@2
+  displayName: 'Copy Obj Files'
+  inputs:
+    Contents: '$(Build.SourcesDirectory)\**\obj\**'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\ObjDirsContents'
+  enabled: false
+  condition: succeededOrFailed()
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish ObjDirsContents'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\ObjDirsContents'
+    ArtifactName: ObjDirsContents
+  enabled: false
+  condition: succeededOrFailed()
+
+- task: CopyFiles@2
+  displayName: 'Copy Files to PackagesContents'
+  inputs:
+    SourceFolder: '$(Build.Repository.LocalPath)\setup\wix'
+    Contents: 'packages\**'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\PackagesContents'
+  enabled: false
+  condition: succeededOrFailed()
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Packages Contents'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\PackagesContents'
+    ArtifactName: PackagesContents
+  enabled: false
+  condition: succeededOrFailed()
+
+
+


### PR DESCRIPTION
Create a separate Yaml for PR builds

This is the same as build/EF6Tools-VS2019-Nightly-PR.yaml, except some steps related to signing/etc. are removed and a trigger intended for this to run on PRs has been added.