### PR TITLE
Allow multiple ProjectReferences to use the same Reference

### DIFF
--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/DatabaseGenerationAssemblyLoader.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/DatabaseGenerationAssemblyLoader.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
                 }
 
                 if (reference.Resolved
-                    && !string.IsNullOrEmpty(reference.Path))
+                    && !string.IsNullOrEmpty(reference.Path)
+                    && !_projectReferenceLookup.ContainsKey(reference.Identity))
                 {
                     _projectReferenceLookup.Add(reference.Identity, reference);
                 }


### PR DESCRIPTION
Fix issue where the same binary is listed twice in the set of Reference items (transitively, from a ProjectReference)