### PR TITLE
change methods to "FromDesignTime"

### DIFF
--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/DatabaseConnectionSsdlAggregator.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/DatabaseConnectionSsdlAggregator.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
     // </summary>
     internal class DatabaseConnectionSsdlAggregator
     {
-        private readonly ModelBuilderSettings _settings;
+        private readonly ISchemaListingSettings _settings;
 
-        internal DatabaseConnectionSsdlAggregator(ModelBuilderSettings settings)
+        internal DatabaseConnectionSsdlAggregator(ISchemaListingSettings settings)
         {
             _settings = settings;
         }

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/DatabaseMetadataQueryTool.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/DatabaseMetadataQueryTool.cs
@@ -17,20 +17,20 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
     internal static class DatabaseMetadataQueryTool
     {
         internal static ICollection<EntityStoreSchemaFilterEntry> GetTablesFilterEntries(
-            ModelBuilderSettings settings, DoWorkEventArgs args)
+            ISchemaListingSettings settings, DoWorkEventArgs args)
         {
             var entries = ExecuteDatabaseMetadataQuery(SelectTablesESqlQuery, EntityStoreSchemaFilterObjectTypes.Table, settings, args);
             return entries;
         }
 
-        internal static ICollection<EntityStoreSchemaFilterEntry> GetViewFilterEntries(ModelBuilderSettings settings, DoWorkEventArgs args)
+        internal static ICollection<EntityStoreSchemaFilterEntry> GetViewFilterEntries(ISchemaListingSettings settings, DoWorkEventArgs args)
         {
             var entries = ExecuteDatabaseMetadataQuery(SelectViewESqlQuery, EntityStoreSchemaFilterObjectTypes.View, settings, args);
             return entries;
         }
 
         internal static ICollection<EntityStoreSchemaFilterEntry> GetFunctionsFilterEntries(
-            ModelBuilderSettings settings, DoWorkEventArgs args)
+            ISchemaListingSettings settings, DoWorkEventArgs args)
         {
             ICollection<EntityStoreSchemaFilterEntry> entries;
 
@@ -53,7 +53,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
         [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities",
             Justification = "The only SQL passed to this method consists of pre-defined queries over which the user has no control")]
         private static ICollection<EntityStoreSchemaFilterEntry> ExecuteDatabaseMetadataQuery(
-            string esqlQuery, EntityStoreSchemaFilterObjectTypes types, ModelBuilderSettings settings, DoWorkEventArgs args)
+            string esqlQuery, EntityStoreSchemaFilterObjectTypes types, ISchemaListingSettings settings, DoWorkEventArgs args)
         {
             var filterEntries = new List<EntityStoreSchemaFilterEntry>();
 
@@ -61,10 +61,11 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
             try
             {
                 Version actualEntityFrameworkConnectionVersion;
+
                 ec = new StoreSchemaConnectionFactory().Create(
                     DependencyResolver.Instance,
                     settings.RuntimeProviderInvariantName,
-                    settings.DesignTimeConnectionString,
+                    settings.RuntimeConnectionString,
                     settings.TargetSchemaVersion,
                     out actualEntityFrameworkConnectionVersion);
 

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/ISchemaListingSettings.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/ISchemaListingSettings.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
+{
+    using System;
+
+    internal interface ISchemaListingSettings
+    {
+        /// <summary>
+        /// EF Schema Version
+        /// </summary>
+        Version TargetSchemaVersion { get; }
+
+        /// <summary>
+        /// Runtime Provider Invariant Name
+        /// </summary>
+        string RuntimeProviderInvariantName { get; }
+
+        /// <summary>
+        /// Runtime Connection string value
+        /// </summary>
+        string RuntimeConnectionString { get; }
+    }
+}

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/ModelBuilderSettings.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/ModelBuilderSettings.cs
@@ -155,28 +155,28 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
         // <summary>
         //     This will set up the design-time &amp; runtime invariant name properties &amp; connection string properties.
         // </summary>
-        // <param name="isDesignTime">Indicates if invariant name &amp; connection strings are design-time or runtime.</param>
+        // <param name="fromDesignTime">Indicates if invariant name &amp; connection strings are from design-time (if false, ,from runtime)</param>
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1614:ElementParameterDocumentationMustHaveText")]
         internal void SetInvariantNamesAndConnectionStrings(IServiceProvider serviceProvider,
-            Project project, string invariantName, string connectionString, string appConfigConnectionString, bool isDesignTime)
+            Project project, string invariantName, string connectionString, string appConfigConnectionString, bool fromDesignTime)
         {
-            if (isDesignTime)
+            if (fromDesignTime)
             {
                 _designTimeConnectionString = connectionString;
-                _appConfigConnectionString = ConnectionManager.TranslateConnectionString(
-                    serviceProvider, project, invariantName, appConfigConnectionString, true);
+                _appConfigConnectionString = ConnectionManager.TranslateConnectionStringFromDesignTime(
+                    serviceProvider, project, invariantName, appConfigConnectionString);
                 _designTimeProviderInvariantName = invariantName;
-                _runtimeProviderInvariantName = ConnectionManager.TranslateInvariantName(
-                    serviceProvider, _designTimeProviderInvariantName, _designTimeConnectionString, true);
+                _runtimeProviderInvariantName = ConnectionManager.TranslateInvariantNameFromDesignTime(
+                    serviceProvider, _designTimeProviderInvariantName, _designTimeConnectionString);
             }
             else
             {
-                _designTimeConnectionString = ConnectionManager.TranslateConnectionString(
-                    serviceProvider, project, invariantName, connectionString, false);
+                _designTimeConnectionString = ConnectionManager.TranslateConnectionStringFromRunTime(
+                    serviceProvider, project, invariantName, connectionString);
                 _appConfigConnectionString = appConfigConnectionString;
                 _runtimeProviderInvariantName = invariantName;
-                _designTimeProviderInvariantName = ConnectionManager.TranslateInvariantName(
-                    serviceProvider, _runtimeProviderInvariantName, _designTimeConnectionString, false);
+                _designTimeProviderInvariantName = ConnectionManager.TranslateInvariantNameFromRunTime(
+                    serviceProvider, _runtimeProviderInvariantName, _designTimeConnectionString);
             }
         }
 

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/SchemaListingSettings.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/SchemaListingSettings.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
+{
+    using System;
+    using Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine;
+    using Microsoft.Data.Entity.Design.VisualStudio.Package;
+
+    /// <summary>
+    /// This object adapts the properties of the ModelBuilderWizardForm into a consistent form for getting the schema of a SQL Server
+    /// </summary>
+    internal sealed class SchemaListingSettings : ISchemaListingSettings
+    {
+        public Version TargetSchemaVersion { get; private set; }
+
+        public string RuntimeProviderInvariantName { get; private set; }
+
+        public string RuntimeConnectionString { get; private set; }
+
+        internal static SchemaListingSettings FromWizard(ModelBuilderWizardForm wizard)
+        {
+            string runtimeConnectionString = ConnectionManager.TranslateConnectionStringFromDesignTime(
+                wizard.ServiceProvider,
+                wizard.ModelBuilderSettings.Project,
+                wizard.ModelBuilderSettings.RuntimeProviderInvariantName,
+                wizard.ModelBuilderSettings.DesignTimeConnectionString);
+
+            SchemaListingSettings settings = new SchemaListingSettings()
+            {
+                TargetSchemaVersion = wizard.ModelBuilderSettings.TargetSchemaVersion,
+                RuntimeProviderInvariantName = wizard.ModelBuilderSettings.RuntimeProviderInvariantName,
+                RuntimeConnectionString = runtimeConnectionString,
+            };
+            return settings;
+        }
+    }
+}

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageDbConfig.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageDbConfig.cs
@@ -679,15 +679,12 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
             var fixedDecryptedConnectionString = ReplaceMdsKeywords(decryptedConnectionString);
             var fixedAppConfigConnectionString = ReplaceMdsKeywords(appConfigConnectionString);
             Wizard.ModelBuilderSettings.SetInvariantNamesAndConnectionStrings(ServiceProvider,
-                Wizard.Project, invariantName, fixedDecryptedConnectionString, fixedAppConfigConnectionString, true);
+                Wizard.Project, invariantName, fixedDecryptedConnectionString, fixedAppConfigConnectionString, fromDesignTime:true);
 
             string ReplaceMdsKeywords(string connectionString)
             {
                 connectionString = connectionString.Replace("Multiple Active Result Sets=", "MultipleActiveResultSets=")
-                    .Replace("Trust Server Certificate=", "TrustServerCertificate=")
-                    .Replace("Authentication=ActiveDirectoryIntegrated", "Authentication=Active Directory Integrated")
-                    .Replace("Authentication=ActiveDirectoryPassword", "Authentication=Active Directory Password")
-                    .Replace("Authentication=ActiveDirectoryInteractive", "Authentication=Active Directory Interactive");
+                    .Replace("Trust Server Certificate=", "TrustServerCertificate=");
                 return connectionString;
             }
         }
@@ -697,11 +694,11 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
         {
             // providerGuid will be the design-time provider guid from DDEX, so we need to translate to the runtime provider invariant name 
             var designTimeProviderInvariantName = DataConnectionUtils.GetProviderInvariantName(dataProviderManager, providerGuid);
-            var runtimeProviderInvariantName = ConnectionManager.TranslateInvariantName(
-                ServiceProvider, designTimeProviderInvariantName, maskedConnectionString, true);
+            var runtimeProviderInvariantName = ConnectionManager.TranslateInvariantNameFromDesignTime(
+                ServiceProvider, designTimeProviderInvariantName, maskedConnectionString);
 
-            var runtimeConnectionString = ConnectionManager.TranslateConnectionString(ServiceProvider,
-                Wizard.Project, designTimeProviderInvariantName, maskedConnectionString, true);
+            var runtimeConnectionString = ConnectionManager.TranslateConnectionStringFromDesignTime(ServiceProvider,
+                Wizard.Project, runtimeProviderInvariantName, maskedConnectionString);
 
             if (Wizard.ModelBuilderSettings.GenerationOption == ModelGenerationOption.GenerateFromDatabase
                 || Wizard.ModelBuilderSettings.GenerationOption == ModelGenerationOption.GenerateDatabaseScript)

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageRuntimeConfig.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageRuntimeConfig.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
     using Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine;
     using Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui.ViewModels;
     using Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Properties;
+    using Microsoft.Data.Entity.Design.VisualStudio.Package;
     using Microsoft.WizardFramework;
 
     internal partial class WizardPageRuntimeConfig : WizardPageBase
@@ -102,11 +103,14 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
                     Wizard.Project,
                     ServiceProvider);
 
+                string runtimeConnectionString = ConnectionManager.TranslateConnectionStringFromDesignTime(
+                     ServiceProvider, Wizard.Project, Wizard.ModelBuilderSettings.RuntimeProviderInvariantName, Wizard.ModelBuilderSettings.DesignTimeConnectionString);
+
                 Wizard.ModelBuilderSettings.ProviderManifestToken =
                     VsUtils.GetProviderManifestTokenConnected(
                         DependencyResolver.Instance,
                         Wizard.ModelBuilderSettings.RuntimeProviderInvariantName,
-                        Wizard.ModelBuilderSettings.DesignTimeConnectionString);
+                        runtimeConnectionString);
             }
 
             return base.OnDeactivate();

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageSelectTables.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageSelectTables.cs
@@ -357,7 +357,8 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
             // Be sure not to manipulate any Windows Forms controls created on the UI thread from this method.
             using (new VsUtils.HourglassHelper())
             {
-                var ssdlAggregator = new DatabaseConnectionSsdlAggregator(Wizard.ModelBuilderSettings);
+                SchemaListingSettings schemaListingSettings = SchemaListingSettings.FromWizard(Wizard);
+                var ssdlAggregator = new DatabaseConnectionSsdlAggregator(schemaListingSettings);
 
                 var result = new ICollection<EntityStoreSchemaFilterEntry>[3];
                 try

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageStart.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageStart.cs
@@ -259,7 +259,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
 
                 Wizard.ModelBuilderSettings.SetInvariantNamesAndConnectionStrings(
                     ServiceProvider, Wizard.Project, ConnectionManager.SqlClientProviderName,
-                    defaultConnectionString, defaultConnectionString, isDesignTime: false);
+                    defaultConnectionString, defaultConnectionString, fromDesignTime: false);
             }
         }
 

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageUpdateFromDatabase.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageUpdateFromDatabase.cs
@@ -316,21 +316,24 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
             // This method will run on a thread other than the UI thread.
             // Be sure not to manipulate any Windows Forms controls created on the UI thread from this method.
             var result = new ICollection<EntityStoreSchemaFilterEntry>[3];
+
+            SchemaListingSettings schemaListingSettings = SchemaListingSettings.FromWizard(Wizard);
+
             try
             {
-                result[0] = DatabaseMetadataQueryTool.GetTablesFilterEntries(Wizard.ModelBuilderSettings, args);
+                result[0] = DatabaseMetadataQueryTool.GetTablesFilterEntries(schemaListingSettings, args);
                 if (args.Cancel)
                 {
                     return;
                 }
 
-                result[1] = DatabaseMetadataQueryTool.GetViewFilterEntries(Wizard.ModelBuilderSettings, args);
+                result[1] = DatabaseMetadataQueryTool.GetViewFilterEntries(schemaListingSettings, args);
                 if (args.Cancel)
                 {
                     return;
                 }
 
-                result[2] = DatabaseMetadataQueryTool.GetFunctionsFilterEntries(Wizard.ModelBuilderSettings, args);
+                result[2] = DatabaseMetadataQueryTool.GetFunctionsFilterEntries(schemaListingSettings, args);
                 if (args.Cancel)
                 {
                     return;

--- a/test/EFTools/UnitTests/EntityDesign/VisualStudio/ModelWizard/Gui/WizardPageStartTests.cs
+++ b/test/EFTools/UnitTests/EntityDesign/VisualStudio/ModelWizard/Gui/WizardPageStartTests.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
     <add name=""myModel"" connectionString=""Data Source=(localdb)\{0};"" providerName=""System.Data.SqlClient"" />
   </connectionStrings>
 </configuration>",
-#if (VS14 || VS15)
+#if (VS14 || VS15 || VS16 || VS17)
     "MSSQLLocalDB"
 #else
     "v11.0"
@@ -209,7 +209,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
             Assert.Equal(@"myModel1", modelBuilderSettings.AppConfigConnectionPropertyName);
             Assert.True(modelBuilderSettings.SaveConnectionStringInAppConfig);
             Assert.Equal(
-#if (VS14 || VS15)
+#if (VS14 || VS15 || VS16 || VS17)
                 @"Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=modelNamespace.myModel;Integrated Security=True",
 #else
                 @"Data Source=(LocalDb)\v11.0;Initial Catalog=modelNamespace.myModel;Integrated Security=True",

--- a/test/EFTools/UnitTests/EntityDesign/VisualStudio/Package/ConnectionManagerTests.cs
+++ b/test/EFTools/UnitTests/EntityDesign/VisualStudio/Package/ConnectionManagerTests.cs
@@ -111,26 +111,26 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.Package
 
             Assert.Same(
                 connString,
-                ConnectionManager.TranslateConnectionString(
-                    Mock.Of<IServiceProvider>(), Mock.Of<Project>(), "invariantName", connString, true));
+                ConnectionManager.TranslateConnectionStringFromDesignTime(
+                    Mock.Of<IServiceProvider>(), Mock.Of<Project>(), "invariantName", connString));
 
             Assert.Same(
                 connString,
-                ConnectionManager.TranslateConnectionString(
-                    Mock.Of<IServiceProvider>(), Mock.Of<Project>(), "invariantName", connString, false));
+                ConnectionManager.TranslateConnectionStringFromRunTime(
+                    Mock.Of<IServiceProvider>(), Mock.Of<Project>(), "invariantName", connString));
         }
 
         [Fact]
         public void TranslateConnectionString_returns_connection_string_if_connection_string_null_or_empty()
         {
             Assert.Null(
-                ConnectionManager.TranslateConnectionString(
-                    Mock.Of<IServiceProvider>(), Mock.Of<Project>(), "invariantName", null, true));
+                ConnectionManager.TranslateConnectionStringFromDesignTime(
+                    Mock.Of<IServiceProvider>(), Mock.Of<Project>(), "invariantName", null));
 
             Assert.Same(
                 string.Empty,
-                ConnectionManager.TranslateConnectionString(
-                    Mock.Of<IServiceProvider>(), Mock.Of<Project>(), "invariantName", string.Empty, false));
+                ConnectionManager.TranslateConnectionStringFromRunTime(
+                    Mock.Of<IServiceProvider>(), Mock.Of<Project>(), "invariantName", string.Empty));
         }
 
         [Fact]
@@ -150,8 +150,8 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.Package
 
             Assert.Same(
                 runtimeConnString,
-                ConnectionManager.TranslateConnectionString(
-                    mockServiceProvider.Object, Mock.Of<Project>(), "My.Db", "designTimeConnString", true));
+                ConnectionManager.TranslateConnectionStringFromDesignTime(
+                    mockServiceProvider.Object, Mock.Of<Project>(), "My.Db", "designTimeConnString"));
         }
 
         [Fact]
@@ -171,8 +171,8 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.Package
 
             Assert.Same(
                 designTimeConnString,
-                ConnectionManager.TranslateConnectionString(
-                    mockServiceProvider.Object, Mock.Of<Project>(), "My.Db", "runtimeTimeConnString", false));
+                ConnectionManager.TranslateConnectionStringFromRunTime(
+                    mockServiceProvider.Object, Mock.Of<Project>(), "My.Db", "runtimeTimeConnString"));
         }
 
         [Fact]
@@ -213,14 +213,14 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.Package
             Assert.Equal(
                 string.Format(Resources.CannotTranslateRuntimeConnectionString, string.Empty, "connectionString"),
                 Assert.Throws<ArgumentException>(
-                    () => ConnectionManager.TranslateConnectionString(mockServiceProvider.Object,
-                        Mock.Of<Project>(), "My.Db", "connectionString", false)).Message);
+                    () => ConnectionManager.TranslateConnectionStringFromRunTime(mockServiceProvider.Object,
+                        Mock.Of<Project>(), "My.Db", "connectionString")).Message);
 
             Assert.Equal(
                 string.Format(Resources.CannotTranslateDesignTimeConnectionString, string.Empty, "connectionString"),
                 Assert.Throws<ArgumentException>(
-                    () => ConnectionManager.TranslateConnectionString(mockServiceProvider.Object,
-                        Mock.Of<Project>(), "My.Db", "connectionString", true)).Message);
+                    () => ConnectionManager.TranslateConnectionStringFromDesignTime(mockServiceProvider.Object,
+                        Mock.Of<Project>(), "My.Db", "connectionString")).Message);
         }
 
         [Fact]
@@ -268,8 +268,8 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.Package
             Assert.Equal(
                 string.Format(Resources.CannotTranslateRuntimeConnectionString, ddexNotInstalledMessage, "connectionString"),
                 Assert.Throws<ArgumentException>(
-                    () => ConnectionManager.TranslateConnectionString(mockServiceProvider.Object,
-                        Mock.Of<Project>(), "My.Db", "connectionString", false)).Message);
+                    () => ConnectionManager.TranslateConnectionStringFromRunTime(mockServiceProvider.Object,
+                        Mock.Of<Project>(), "My.Db", "connectionString")).Message);
 
             mockProviderMapper
                 .Verify(
@@ -279,8 +279,8 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.Package
             Assert.Equal(
                 string.Format(Resources.CannotTranslateDesignTimeConnectionString, ddexNotInstalledMessage, "connectionString"),
                 Assert.Throws<ArgumentException>(
-                    () => ConnectionManager.TranslateConnectionString(mockServiceProvider.Object,
-                        Mock.Of<Project>(), "My.Db", "connectionString", true)).Message);
+                    () => ConnectionManager.TranslateConnectionStringFromDesignTime(mockServiceProvider.Object,
+                        Mock.Of<Project>(), "My.Db", "connectionString")).Message);
         }
 
         [Fact]
@@ -316,7 +316,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.Package
         public void CreateDefaultLocalDbConnectionString_returns_correct_default_connection_string()
         {
             Assert.Equal(
-#if (VS14 || VS15)
+#if (VS14 || VS15 || VS16 || VS17)
                 @"Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=App.MyContext;Integrated Security=True",
 #else
                 @"Data Source=(LocalDb)\v11.0;Initial Catalog=App.MyContext;Integrated Security=True",


### PR DESCRIPTION
Remove some discrepencies between how VS handles Microsoft.Data.SqlClient and System.Data.SqlClient connection strings.

In general, this means providing either "all runtime" or "all designtime" connection string and provider names to the same method, rather than cases where a mix was provided.