### PR TITLE
Remove un-redisted restore of Microsoft.SqlServer.Compact

### DIFF
--- a/src/EFTools/setup/GenerateMsiInputs/packages.config
+++ b/src/EFTools/setup/GenerateMsiInputs/packages.config
@@ -10,7 +10,6 @@
   <package id="EntityFramework.ru" version="5.0.0" />
   <package id="EntityFramework.zh-Hans" version="5.0.0" />
   <package id="EntityFramework.zh-Hant" version="5.0.0" />
-  <package id="Microsoft.SqlServer.Compact" version="4.0.8876.1" targetFramework="net45" />
   <package id="EntityFramework" version="6.5.1" />
   <package id="EntityFramework.de" version="6.2.0" />
   <package id="EntityFramework.es" version="6.2.0" />


### PR DESCRIPTION
The Microsoft.SqlServer.Compact binaries aren't actually redisted by the ef6tools project (see setup\wix\NuGetPackages.wxs); remove.