### PR TITLE
Allow reading appsetting from App.config/web.config, rather than the devenv.exe config

### DIFF
--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/DatabaseEngineBase.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/DatabaseEngineBase.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
                         runtimeProviderName,
                         runtimeProviderConnectionString,
                         runtimeProviderConnectionString,
-                        false);
+                        fromDesignTime: false);
                     settings.InitialCatalog = initialCatalog;
                     settings.AppConfigConnectionPropertyName = entityContainerName;
                     settings.SaveConnectionStringInAppConfig = false;

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/ModelBuilderSettings.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/ModelBuilderSettings.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
         private string _designTimeProviderInvariantName;
         private string _runtimeProviderInvariantName;
         private string _modelNamespace;
+        private Func<string, object> _fnGetLocalAppSetting;
         private VisualStudioProjectSystem _applicationType;
         private EFArtifact _preexistingEFArtifact;
         private readonly Dictionary<string, Object> _extensionData = new Dictionary<string, Object>();
@@ -116,6 +117,11 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
             }
         }
 
+        internal Func<string, object> FnGetLocalAppSetting()
+        {
+            return _fnGetLocalAppSetting;
+        }
+
         internal string DdlFileName { get; set; }
 
         internal StringReader SsdlStringReader { get; set; }
@@ -157,9 +163,15 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
         // </summary>
         // <param name="fromDesignTime">Indicates if invariant name &amp; connection strings are from design-time (if false, ,from runtime)</param>
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1614:ElementParameterDocumentationMustHaveText")]
-        internal void SetInvariantNamesAndConnectionStrings(IServiceProvider serviceProvider,
-            Project project, string invariantName, string connectionString, string appConfigConnectionString, bool fromDesignTime)
+        internal void SetInvariantNamesAndConnectionStrings(
+            IServiceProvider serviceProvider,
+            Project project,
+            string invariantName,
+            string connectionString,
+            string appConfigConnectionString,
+            bool fromDesignTime)
         {
+            _fnGetLocalAppSetting = VsUtils.GetLocalApplicationSettingImplementation(project); ;
             if (fromDesignTime)
             {
                 _designTimeConnectionString = connectionString;

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/ModelGenerator.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/ModelGenerator.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
         {
             Debug.Assert(storeModel != null, "storeModel != null");
 
-            return 
+            return
                 new OneToOneMappingBuilder(
                     _settings.ModelNamespace,
                     _settings.ModelEntityContainerName,

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/ModelGenerator.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/engine/ModelGenerator.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
 
             return
                 CreateDbSchemaLoader(connection, storeSchemaModelVersion)
-                    .LoadStoreSchemaDetails(facadeFilters.ToList());
+                       .LoadStoreSchemaDetails(facadeFilters.ToList());
         }
 
         internal virtual EntityStoreSchemaGeneratorDatabaseSchemaLoader CreateDbSchemaLoader(
@@ -87,7 +87,8 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
             return
                 new EntityStoreSchemaGeneratorDatabaseSchemaLoader(
                     connection,
-                    storeSchemaModelVersion);
+                    storeSchemaModelVersion,
+                    _settings.FnGetLocalAppSetting());
         }
 
         // internal virtual for testing
@@ -95,7 +96,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
         {
             Debug.Assert(storeModel != null, "storeModel != null");
 
-            return
+            return 
                 new OneToOneMappingBuilder(
                     _settings.ModelNamespace,
                     _settings.ModelEntityContainerName,

--- a/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageDbConfig.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/ModelWizard/gui/WizardPageDbConfig.cs
@@ -555,7 +555,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Gui
             // these connection strings & invariant names are coming from the ddex provider, so these are "design-time"
             Wizard.ModelBuilderSettings.SetInvariantNamesAndConnectionStrings(ServiceProvider,
                 Wizard.Project, Wizard.ModelBuilderSettings.DesignTimeProviderInvariantName, newConnectionString,
-                newAppConfigConnectionString, true);
+                newAppConfigConnectionString, fromDesignTime:true);
             return true;
         }
 

--- a/src/EFTools/EntityDesign/VisualStudio/VsUtils.cs
+++ b/src/EFTools/EntityDesign/VisualStudio/VsUtils.cs
@@ -163,6 +163,32 @@ namespace Microsoft.Data.Entity.Design.VisualStudio
             return path;
         }
 
+        internal static Func<string, object> GetLocalApplicationSettingImplementation(Project project)
+        {
+            AppSettingsSection loadedAppSettings = null;
+            return appSettingName =>
+            {
+                try
+                {
+                    if (loadedAppSettings is null)
+                    {
+                        var configurationFile = GetProjectConfigurationFile(project, Services.ServiceProvider);
+                        var configuration = ConfigurationManager.OpenMappedExeConfiguration(
+                            new ExeConfigurationFileMap { ExeConfigFilename = configurationFile },
+                            ConfigurationUserLevel.None);
+
+                        loadedAppSettings = (AppSettingsSection)configuration.GetSection("appSettings");
+                    }
+
+                    return loadedAppSettings?.Settings[appSettingName]?.Value;
+                }
+                catch (NullReferenceException)
+                {
+                    return null;
+                }
+            };
+        }
+
         // <summary>
         //     Used to resolve a single macro, such as "DevEnvDir", "ProjectDir", or "TargetDir". A dictionary of custom macros can also be passed in
         //     as a 'backup'.

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoader.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoader.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
-    
-   /// <summary>
-   ///     Responsible for Loading Database Schema Information
-   /// </summary>
-   internal class EntityStoreSchemaGeneratorDatabaseSchemaLoader
+
+    /// <summary>
+    ///     Responsible for Loading Database Schema Information
+    /// </summary>
+    internal class EntityStoreSchemaGeneratorDatabaseSchemaLoader
     {
         private const string SqlServerInvariantName = "System.Data.SqlClient";
         private const string SwitchOffMetadataMergeJoinsKey =
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
         public EntityStoreSchemaGeneratorDatabaseSchemaLoader(
             EntityConnection entityConnection,
             Version storeSchemaModelVersion,
-            Func<string,object> lookupValueFromAppSettings)
+            Func<string, object> lookupValueFromAppSettings)
         {
             Debug.Assert(entityConnection != null, "entityConnection != null");
             Debug.Assert(entityConnection.State == ConnectionState.Closed, "expected closed connection");
@@ -284,10 +284,10 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
         {
             var command =
                 new EntityCommand(null, _connection, DependencyResolver.Instance)
-                    {
-                        CommandType = CommandType.Text,
-                        CommandTimeout = 0
-                    };
+                {
+                    CommandType = CommandType.Text,
+                    CommandTimeout = 0
+                };
 
             var optimizeParameters =
                 ((StoreItemCollection)_connection

--- a/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoader.cs
+++ b/src/EFTools/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoader.cs
@@ -14,24 +14,26 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
-
-    /// <summary>
-    ///     Responsible for Loading Database Schema Information
-    /// </summary>
-    internal class EntityStoreSchemaGeneratorDatabaseSchemaLoader
+    
+   /// <summary>
+   ///     Responsible for Loading Database Schema Information
+   /// </summary>
+   internal class EntityStoreSchemaGeneratorDatabaseSchemaLoader
     {
         private const string SqlServerInvariantName = "System.Data.SqlClient";
         private const string SwitchOffMetadataMergeJoinsKey =
             "Switch.Microsoft.Data.Entity.Design.DoNotUseSqlServerMetadataMergeJoins";
         private readonly EntityConnection _connection;
         private readonly Version _storeSchemaModelVersion;
+        private readonly Func<string, object> _lookupValueFromAppSettings;
         private readonly IDbCommandInterceptor _addOptionMergeJoinInterceptor;
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
             Justification = "For this purpose we want to ignore any exception that is thrown.")]
         public EntityStoreSchemaGeneratorDatabaseSchemaLoader(
             EntityConnection entityConnection,
-            Version storeSchemaModelVersion)
+            Version storeSchemaModelVersion,
+            Func<string,object> lookupValueFromAppSettings)
         {
             Debug.Assert(entityConnection != null, "entityConnection != null");
             Debug.Assert(entityConnection.State == ConnectionState.Closed, "expected closed connection");
@@ -39,6 +41,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
 
             _connection = entityConnection;
             _storeSchemaModelVersion = storeSchemaModelVersion;
+            _lookupValueFromAppSettings = lookupValueFromAppSettings;
 
             var isSqlServer = false;
             try
@@ -67,22 +70,52 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
 
         // Checks AppSettings for the quirk which can switch off metadata merge joins
         [SuppressMessage("Microsoft.Usage", "CA1806:DoNotIgnoreMethodResults", MessageId = "System.Boolean.TryParse(System.String,System.Boolean@)")]
-        private static bool SwitchOffMetadataMergeJoins()
+        private bool SwitchOffMetadataMergeJoins()
         {
             var switchOffMetadataMergeJoins = false;
-            var metadataMergeJoinsAppSettings =
-                ConfigurationManager.AppSettings.GetValues(SwitchOffMetadataMergeJoinsKey);
-            if (metadataMergeJoinsAppSettings != null)
+
+            // first we check for the quirk in the AppSettings of the customer project
+            if (_lookupValueFromAppSettings != null)
             {
-                var metadataMergeJoinsAppSetting =
-                    metadataMergeJoinsAppSettings.FirstOrDefault();
-                if (metadataMergeJoinsAppSetting != null)
+                var metadataMergeJoinsAppSettingsObj =
+                    _lookupValueFromAppSettings(SwitchOffMetadataMergeJoinsKey);
+
+                // if the appSetting key has a value, it is conclusive
+                if (metadataMergeJoinsAppSettingsObj != null)
                 {
-                    bool.TryParse(
-                        metadataMergeJoinsAppSetting, out switchOffMetadataMergeJoins);
+                    if (metadataMergeJoinsAppSettingsObj is string metadataMergeJoinsAppSettingsStr)
+                    {
+                        var metadataMergeJoinsAppSetting = metadataMergeJoinsAppSettingsStr;
+                        if (!string.IsNullOrEmpty(metadataMergeJoinsAppSetting))
+                        {
+                            bool.TryParse(
+                                metadataMergeJoinsAppSetting, out switchOffMetadataMergeJoins);
+                        }
+                    }
+                    else if (metadataMergeJoinsAppSettingsObj is bool metadataMergeJoinsAppSettingsBool)
+                    {
+                        switchOffMetadataMergeJoins = metadataMergeJoinsAppSettingsBool;
+                    }
+
+                    return switchOffMetadataMergeJoins;
                 }
             }
-
+            else
+            {
+                // then we check for the quirk in the AppSettings of the devenv.exe.config
+                var metadataMergeJoinsAppSettings =
+                    ConfigurationManager.AppSettings.GetValues(SwitchOffMetadataMergeJoinsKey);
+                if (metadataMergeJoinsAppSettings != null)
+                {
+                    var metadataMergeJoinsAppSetting =
+                        metadataMergeJoinsAppSettings.FirstOrDefault();
+                    if (metadataMergeJoinsAppSetting != null)
+                    {
+                        bool.TryParse(
+                            metadataMergeJoinsAppSetting, out switchOffMetadataMergeJoins);
+                    }
+                }
+            }
             return switchOffMetadataMergeJoins;
         }
 

--- a/test/EFTools/UnitTests/EntityDesign/VisualStudio/ModelWizard/Engine/ModelGeneratorTests.cs
+++ b/test/EFTools/UnitTests/EntityDesign/VisualStudio/ModelWizard/Engine/ModelGeneratorTests.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Data.Entity.Design.VisualStudio.ModelWizard.Engine
 
             mockModelGenerator
                 .Setup(g => g.CreateDbSchemaLoader(It.IsAny<EntityConnection>(), It.IsAny<Version>()))
-                .Returns(new Mock<EntityStoreSchemaGeneratorDatabaseSchemaLoader>(mockEntityConnectionObject, version).Object);
+                .Returns(new Mock<EntityStoreSchemaGeneratorDatabaseSchemaLoader>(mockEntityConnectionObject, version,  /* get app setting func*/ null).Object);
 
             mockModelGenerator.Object.GetStoreSchemaDetails(mockConnectionFactory.Object);
 

--- a/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoaderTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoaderTests.cs
@@ -16,13 +16,14 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
     {
         private readonly EntityClientMockFactory mockDataReaderFactory = new EntityClientMockFactory();
 
-        [Fact(Skip = "Type lacks parameterless constructor in locally built")]
+           [Fact(Skip = "Type lacks parameterless constructor in locally built")]
         public void CreateFilteredCommand_creates_command_and_sets_parameters()
         {
             var command =
                 new EntityStoreSchemaGeneratorDatabaseSchemaLoader(
                     GetMockEntityConnection(false).Object,
-                    EntityFrameworkVersion.Version3)
+                    EntityFrameworkVersion.Version3,
+                    lookupValueFromAppSettings:null)
                     .CreateFilteredCommand(
                         "baseQuery",
                         "orderbyClause",
@@ -55,7 +56,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
 
             Func<Version, string> getCommandText = (version) =>
                                                    new EntityStoreSchemaGeneratorDatabaseSchemaLoader(
-                                                       GetMockEntityConnection(true).Object, version)
+                                                       GetMockEntityConnection(true).Object, version, lookupValueFromAppSettings: null)
                                                        .CreateFunctionDetailsCommand(Enumerable.Empty<EntityStoreSchemaFilterEntry>())
                                                        .CommandText;
 
@@ -112,7 +113,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                         }));
         }
 
-        [Fact(Skip = "Type lacks parameterless constructor in locally built")]
+         [Fact(Skip = "Type lacks parameterless constructor in locally built")]
         public void LoadRelationships_returns_sorted_relationships_details()
         {
             var input =
@@ -152,7 +153,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                 );
         }
 
-        [Fact(Skip = "Type lacks parameterless constructor in locally built")]
+          [Fact(Skip = "Type lacks parameterless constructor in locally built")]
         public void LoadFunctionDetails_returns_function_details()
         {
             var input =
@@ -189,7 +190,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
             Assert.Equal("f2", results[1].ProcedureName);
         }
 
-        [Fact(Skip = "Type lacks parameterless constructor in locally built")]
+             [Fact(Skip = "Type lacks parameterless constructor in locally built")]
         public void LoadStoreSchema_returns_initialized_StoreSchemaInstance()
         {
             var tableCommand =
@@ -267,7 +268,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
             {
                 var mockLoader =
                     new Mock<EntityStoreSchemaGeneratorDatabaseSchemaLoader>(
-                        mockEntityConnection.Object, version)
+                        mockEntityConnection.Object, version, /*get app setting func*/null)
                         {
                             CallBase = true
                         };
@@ -355,7 +356,11 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
             mockProviderManifest
                 .Setup<bool>(pm => pm.SupportsParameterOptimizationInSchemaQueries())
                 .Returns(supportsParameterOptimizationInSchemaQueries);
-            var mockStoreItemCollection = new Mock<StoreItemCollection>();
+
+            var mockEntityContainer = new Mock<EntityContainer>("edm", DataSpace.CSpace);
+            var mockEdmModel = new Mock<EdmModel>(mockEntityContainer.Object, 3.0);
+
+            var mockStoreItemCollection = new Mock<StoreItemCollection>(mockEdmModel.Object);
             mockStoreItemCollection
                 .SetupGet<DbProviderManifest>(p => p.ProviderManifest)
                 .Returns(mockProviderManifest.Object);
@@ -382,7 +387,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
             }
 
             public EntityStoreSchemaGeneratorDatabaseSchemaLoaderFake(EntityCommand[] entityCommands)
-                : base(new Mock<EntityConnection>().Object, EntityFrameworkVersion.Version3)
+                : base(new Mock<EntityConnection>().Object, EntityFrameworkVersion.Version3, lookupValueFromAppSettings: null)
             {
                 _entityCommands = entityCommands;
             }

--- a/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoaderTests.cs
+++ b/test/EFTools/UnitTests/EntityDesignerVersioningFacade/ReverseEngineerDb/SchemaDiscovery/EntityStoreSchemaGeneratorDatabaseSchemaLoaderTests.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
     {
         private readonly EntityClientMockFactory mockDataReaderFactory = new EntityClientMockFactory();
 
-           [Fact(Skip = "Type lacks parameterless constructor in locally built")]
+        [Fact(Skip = "Type lacks parameterless constructor in locally built")]
         public void CreateFilteredCommand_creates_command_and_sets_parameters()
         {
             var command =
                 new EntityStoreSchemaGeneratorDatabaseSchemaLoader(
                     GetMockEntityConnection(false).Object,
                     EntityFrameworkVersion.Version3,
-                    lookupValueFromAppSettings:null)
+                    lookupValueFromAppSettings: null)
                     .CreateFilteredCommand(
                         "baseQuery",
                         "orderbyClause",
@@ -113,7 +113,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                         }));
         }
 
-         [Fact(Skip = "Type lacks parameterless constructor in locally built")]
+        [Fact(Skip = "Type lacks parameterless constructor in locally built")]
         public void LoadRelationships_returns_sorted_relationships_details()
         {
             var input =
@@ -153,7 +153,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                 );
         }
 
-          [Fact(Skip = "Type lacks parameterless constructor in locally built")]
+        [Fact(Skip = "Type lacks parameterless constructor in locally built")]
         public void LoadFunctionDetails_returns_function_details()
         {
             var input =
@@ -190,7 +190,7 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
             Assert.Equal("f2", results[1].ProcedureName);
         }
 
-             [Fact(Skip = "Type lacks parameterless constructor in locally built")]
+        [Fact(Skip = "Type lacks parameterless constructor in locally built")]
         public void LoadStoreSchema_returns_initialized_StoreSchemaInstance()
         {
             var tableCommand =
@@ -269,9 +269,9 @@ namespace Microsoft.Data.Entity.Design.VersioningFacade.ReverseEngineerDb.Schema
                 var mockLoader =
                     new Mock<EntityStoreSchemaGeneratorDatabaseSchemaLoader>(
                         mockEntityConnection.Object, version, /*get app setting func*/null)
-                        {
-                            CallBase = true
-                        };
+                    {
+                        CallBase = true
+                    };
 
                 mockLoader.Setup(l => l.LoadTableDetails(It.IsAny<IEnumerable<EntityStoreSchemaFilterEntry>>()))
                     .Returns(Enumerable.Empty<TableDetailsRow>());


### PR DESCRIPTION
All reading appsetting from App.config/web.config, rather than the devenv.exe config

In reference to https://developercommunity.visualstudio.com/t/EDMX-not-working-in-newer-versions/10848967