### PR TITLE
Restore MicroBuild.Core NuGet package in pipeline

### DIFF
--- a/build/EF6Tools-VS2017-Nightly.yaml
+++ b/build/EF6Tools-VS2017-Nightly.yaml
@@ -51,6 +51,13 @@ steps:
   inputs:
     signType: '$(SigningType)'
 
+- task: NuGetCommand@2
+  displayName: 'NuGet Restore MicroBuild Core'
+  inputs:
+    command: custom
+    feedsToUse: config
+    arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
+
 - task: MSBuild@1
   displayName: Sign Unlocalized and Localized Assemblies
   inputs:

--- a/build/EF6Tools-VS2019-Nightly-PR.yaml
+++ b/build/EF6Tools-VS2019-Nightly-PR.yaml
@@ -50,6 +50,14 @@ steps:
     configuration: '$(BuildConfiguration)'
     msbuildArguments: '/t:PostBuild -binaryLogger:logfile=$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\Localize.binlog'
 
+- task: NuGetCommand@2
+  displayName: 'NuGet Restore MicroBuild Core'
+  inputs:
+    command: custom
+    feedsToUse: config
+    externalFeedCredentials: 'OSSCG Feed - Microsoft approved OSS packages'
+    arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
+
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@4
   displayName: 'Install Swix Plugin'
 

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -97,6 +97,14 @@ extends:
             configuration: '$(BuildConfiguration)'
             msbuildArguments: '/t:PostBuild'
 
+        - task: NuGetCommand@2
+          displayName: 'NuGet Restore MicroBuild Core'
+          inputs:
+            command: custom
+            feedsToUse: config
+            externalFeedCredentials: 'OSSCG Feed - Microsoft approved OSS packages'
+            arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
+
         - task: MSBuild@1
           displayName: 'Sign Unlocalized and Localized Assemblies'
           inputs:


### PR DESCRIPTION
sign.proj imports MicroBuild.Core.props from MsiRuntimeInputs\packages\. The previous commit removed the NuGet restore pipeline step that placed MicroBuild.Core there, breaking the sign step with MSB4019.

Add the NuGet restore step back in all three pipeline yamls. The packages.config now only contains MicroBuild.Core (all EntityFramework entries were removed in the previous commit).