### PR TITLE
Restore EF packages for VSIX and re-sign with SHA256

### DIFF
--- a/build/EF6Tools-VS2019-Nightly-PR.yaml
+++ b/build/EF6Tools-VS2019-Nightly-PR.yaml
@@ -51,12 +51,18 @@ steps:
     msbuildArguments: '/t:PostBuild -binaryLogger:logfile=$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\Localize.binlog'
 
 - task: NuGetCommand@2
-  displayName: 'NuGet Restore MicroBuild Core'
+  displayName: 'NuGet Restore Setup Inputs Packages'
   inputs:
     command: custom
     feedsToUse: config
     externalFeedCredentials: 'OSSCG Feed - Microsoft approved OSS packages'
     arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
+
+- task: BatchScript@1
+  displayName: 'Extract Setup Inputs Nuspecs'
+  inputs:
+    filename: '$(comspec)'
+    arguments: '/c "call "$(ProgramFiles)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" & msbuild $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\GenerateMsiInputs.msbuild /p:Configuration=$(BuildConfiguration) /t:ExtractNuspecs"'
 
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@4
   displayName: 'Install Swix Plugin'

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -98,7 +98,7 @@ extends:
             msbuildArguments: '/t:PostBuild'
 
         - task: NuGetCommand@2
-          displayName: 'NuGet Restore MicroBuild Core'
+          displayName: 'NuGet Restore Setup Inputs Packages'
           inputs:
             command: custom
             feedsToUse: config
@@ -111,6 +111,12 @@ extends:
             solution: 'build\sign.proj'
             configuration: '$(BuildConfiguration)'
             msbuildArguments: '/t:AfterBuild'
+
+        - task: BatchScript@1
+          displayName: 'Extract Setup Inputs Nuspecs'
+          inputs:
+            filename: '$(comspec)'
+            arguments: '/c "call "$(ProgramFiles)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" & msbuild $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\GenerateMsiInputs.msbuild /p:Configuration=$(BuildConfiguration) /t:ExtractNuspecs"'
 
         - task: MSBuild@1
           displayName: 'Restore VSIX project'

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -23,11 +23,31 @@
       <LocalizedEFToolsDLLs Include="$(RepositoryRootDirectory)bin\$(Configuration)\Microsoft.Data.Tools.Design.XmlCore.dll" />
       <LocalizedEFToolsDLLs Include="$(RepositoryRootDirectory)bin\$(Configuration)\Microsoft.VisualStudio.Data.Tools.Design.XmlCore.dll" />
       <LocalizedEFToolsDLLs Include="$(LocOutDir)\**\*.resources.dll" />
+
+      <!-- EntityFramework NuGet package contents shipped in the VSIX.
+           These packages contain DLLs with SHA1-only Microsoft Authenticode
+           signatures. Re-sign with SHA256 (Microsoft400) before the VSIX
+           build packages them. -->
+      <MsiInputDlls Include="$(RepositoryRootDirectory)bin\$(Configuration)\MsiRuntimeInputs\packages\**\*.dll" />
+      <MsiInputExes Include="$(RepositoryRootDirectory)bin\$(Configuration)\MsiRuntimeInputs\packages\**\*.exe" />
+      <MsiInputPs1s Include="$(RepositoryRootDirectory)bin\$(Configuration)\MsiRuntimeInputs\packages\**\*.ps1" />
     </ItemGroup>
     <ItemGroup>
       <FilesToSign Include="@(LocalizedEFToolsDLLs)">
         <Authenticode>Microsoft400</Authenticode>
         <StrongName>67</StrongName>
+      </FilesToSign>
+      <!-- Authenticode-only re-sign for NuGet package contents.
+           These assemblies already have valid strong names; only the
+           Authenticode signature needs upgrading from SHA1 to SHA256. -->
+      <FilesToSign Include="@(MsiInputDlls)">
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="@(MsiInputExes)">
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="@(MsiInputPs1s)">
+        <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
     </ItemGroup>
 

--- a/src/EFTools/setup/GenerateMsiInputs/packages.config
+++ b/src/EFTools/setup/GenerateMsiInputs/packages.config
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EntityFramework" version="5.0.0" />
+  <package id="EntityFramework" version="6.5.1" />
+  <package id="EntityFramework.de" version="6.2.0" />
+  <package id="EntityFramework.es" version="6.2.0" />
+  <package id="EntityFramework.fr" version="6.2.0" />
+  <package id="EntityFramework.it" version="6.2.0" />
+  <package id="EntityFramework.ja" version="6.2.0" />
+  <package id="EntityFramework.ko" version="6.2.0" />
+  <package id="EntityFramework.ru" version="6.2.0" />
+  <package id="EntityFramework.zh-Hans" version="6.2.0" />
+  <package id="EntityFramework.zh-Hant" version="6.2.0" />
+  <package id="EntityFramework.SqlServerCompact" version="6.5.1" />
+
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" />
 </packages>


### PR DESCRIPTION
The VSIX (files.swr) ships EntityFramework DLLs into Common7\IDE for the EF6 designer to load at runtime. These are distinct from the MSI's offline NuGet cache that was correctly removed in the previous commit.

Restore the EntityFramework packages in packages.config (minus the localized 5.0.0 variants that were MSI-only), add the Extract Nuspecs pipeline step back, and add re-signing with Microsoft400 in sign.proj to upgrade the SHA1-only Authenticode signatures to SHA256.

This fixes build 13861243 which failed with SWIX1108 because the VSIX build could not find the EntityFramework DLLs.