### PR TITLE
Remove registry-based NuGet package lookup from vstemplate files

### DIFF
--- a/src/EFTools/EntityDesign/EntityDesign.csproj
+++ b/src/EFTools/EntityDesign/EntityDesign.csproj
@@ -1021,7 +1021,7 @@
       <InTheBoxItemTemplateFiles Include="VisualStudio\InTheBoxItemTemplates\*.vstman" />
     </ItemGroup>
     <MakeDir Directories="@(InTheBoxItemTemplateFiles->'$(TargetItemTemplateFilesDir)\%(RecursiveDir)')" />
-    <RegexReplaceInFile Condition="'%(Extension)' == '.vstemplate'" InputFileName="%(InTheBoxItemTemplateFiles.Identity)" OutputFileName="@(InTheBoxItemTemplateFiles->'$(TargetItemTemplateFilesDir)\%(RecursiveDir)%(Filename)%(Extension)')" Patterns="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN;EFPACKAGEVERSION;EFDESIGNERVERSIONTOKEN" Replacements="EntityFrameworkVisualStudio17Tools;$(EF6NuGetPackageVersion);$(AssemblyVersion)" />
+    <RegexReplaceInFile Condition="'%(Extension)' == '.vstemplate'" InputFileName="%(InTheBoxItemTemplateFiles.Identity)" OutputFileName="@(InTheBoxItemTemplateFiles->'$(TargetItemTemplateFilesDir)\%(RecursiveDir)%(Filename)%(Extension)')" Patterns="EFPACKAGEVERSION;EFDESIGNERVERSIONTOKEN" Replacements="$(EF6NuGetPackageVersion);$(AssemblyVersion)" />
     <Copy Condition="'%(Extension)' != '.vstemplate'" SourceFiles="@(InTheBoxItemTemplateFiles)" DestinationFiles="@(InTheBoxItemTemplateFiles->'$(TargetItemTemplateFilesDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
   <Target Name="CreateTemplatesAndPackages" DependsOnTargets="UpdateTemplateVersion;PrepareTemplatesForSetup">

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1028/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1028/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1031/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1031/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1033/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1033/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1034/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1034/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1036/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1036/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1040/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1040/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1041/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1041/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1042/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1042/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1049/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1049/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/2052/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/2052/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1028/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1028/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1031/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1031/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1033/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1033/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1034/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1034/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1036/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1036/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1040/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1040/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1041/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1041/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1042/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1042/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1049/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1049/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/2052/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/2052/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1028/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1028/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1031/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1031/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1033/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1033/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1034/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1034/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1036/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1036/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1040/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1040/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1041/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1041/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1042/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1042/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1049/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1049/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/2052/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/2052/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1028/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1028/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1031/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1031/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1033/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1033/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1034/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1034/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1036/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1036/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1040/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1040/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1041/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1041/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1042/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1042/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1049/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1049/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/2052/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/2052/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1028/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1028/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 產生器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hant" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1028/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1028/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 產生器</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1031/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1031/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x-DbContext-Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.de" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1031/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1031/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x-DbContext-Generator</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1033/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1033/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1033/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1033/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext Generator</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1034/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1034/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 5.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.es" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1034/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1034/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 6.x</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1036/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1036/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 5.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.fr" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1036/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1036/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 6.x</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1040/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1040/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 5.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.it" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1040/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1040/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 6.x DbContext</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1041/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1041/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext ジェネレーター</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ja" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1041/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1041/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext ジェネレーター</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1042/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1042/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 생성기</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ko" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1042/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1042/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 생성기</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1049/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1049/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 5.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ru" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1049/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1049/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 6.x DbContext</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/2052/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/2052/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 生成器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hans" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/2052/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/2052/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 生成器</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_CS_V5.0.vstemplate
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_CS_WS_V5.0.vstemplate
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_VB_V5.0.vstemplate
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_VB_WS_V5.0.vstemplate
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_CS_V6.0.vstemplate
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_CS_WS_V6.0.vstemplate
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_VB_V6.0.vstemplate
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_VB_WS_V6.0.vstemplate
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1028/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1028/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 產生器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hant" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1028/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1028/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 產生器</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1031/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1031/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x-DbContext-Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.de" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1031/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1031/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x-DbContext-Generator</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1033/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1033/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1033/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1033/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext Generator</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1034/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1034/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 5.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.es" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1034/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1034/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 6.x</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1036/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1036/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 5.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.fr" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1036/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1036/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 6.x</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1040/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1040/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 5.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.it" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1040/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1040/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 6.x DbContext</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1041/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1041/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext ジェネレーター</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ja" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1041/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1041/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext ジェネレーター</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1042/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1042/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 생성기</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ko" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1042/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1042/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 생성기</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1049/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1049/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 5.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ru" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1049/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1049/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 6.x DbContext</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/2052/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/2052/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 生成器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hans" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/2052/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/2052/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 生成器</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1028/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1028/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 產生器</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hant" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1028/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1028/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 產生器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1031/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1031/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x-DbContext-Generator</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.de" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1031/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1031/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x-DbContext-Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1033/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1033/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext Generator</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1033/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1033/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1034/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1034/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 5.x</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.es" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1034/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1034/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 6.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1036/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1036/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 5.x</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.fr" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1036/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1036/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 6.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1040/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1040/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 5.x DbContext</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.it" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1040/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1040/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 6.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1041/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1041/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext ジェネレーター</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ja" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1041/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1041/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext ジェネレーター</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1042/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1042/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 생성기</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ko" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1042/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1042/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 생성기</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1049/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1049/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 5.x DbContext</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ru" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1049/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1049/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 6.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/2052/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/2052/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 生成器</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hans" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/2052/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/2052/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 生成器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1028/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1028/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 產生器</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hant" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1028/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1028/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 產生器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1031/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1031/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x-DbContext-Generator</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.de" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1031/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1031/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x-DbContext-Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1033/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1033/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext Generator</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1033/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1033/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1034/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1034/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 5.x</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.es" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1034/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1034/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 6.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1036/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1036/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 5.x</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.fr" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1036/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1036/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 6.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1040/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1040/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 5.x DbContext</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.it" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1040/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1040/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 6.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1041/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1041/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext ジェネレーター</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ja" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1041/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1041/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext ジェネレーター</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1042/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1042/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 생성기</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ko" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1042/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1042/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 생성기</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1049/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1049/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 5.x DbContext</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ru" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1049/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1049/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 6.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/2052/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/2052/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 生成器</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hans" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/2052/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/2052/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 生成器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
+    <packages>
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>


### PR DESCRIPTION
PR #86 removed the WiX component (NuGetPackages.wxs) that created the HKLM\Software\NuGet\Repository\EntityFrameworkVisualStudio17Tools registry key. The vstemplate files still referenced this key via repository="registry" keyName="...", causing NuGet's TemplateWizard to fail with 'Could not find a Registry key' when adding an ADO.NET Entity Data Model.

Remove the repository/keyName/isPreunzipped attributes from all 132 vstemplate files so NuGet installs EntityFramework from configured package sources instead of the now-deleted offline cache. Also remove the NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN token replacement from the build since it is no longer needed.