### PR TITLE
Revert PRs #86-89: Restore MSI NuGet cache, registry key, and vstemplate files

### DIFF
--- a/build/EF6Tools-VS2017-Nightly.yaml
+++ b/build/EF6Tools-VS2017-Nightly.yaml
@@ -11,9 +11,9 @@ queue:
   - msbuild
 
 
-#Your build pipeline references an undefined variable named â€˜comspecâ€™. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
-#Your build pipeline references an undefined variable named â€˜comspecâ€™. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
-#Your build pipeline references an undefined variable named â€˜comspecâ€™. Create or edit the build pipeline for this YAML file, define the 
+#Your build pipeline references an undefined variable named ‘comspec’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+#Your build pipeline references an undefined variable named ‘comspec’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+#Your build pipeline references an undefined variable named ‘comspec’. Create or edit the build pipeline for this YAML file, define the 
 
 ##LAJvariables:
 ##LAJ  SingletonMsiName: 'EF6Tools'
@@ -57,6 +57,12 @@ steps:
     solution: 'build\sign.proj'
     configuration: '$(BuildConfiguration)'
     msbuildArguments: '/t:AfterBuild'
+
+- task: BatchScript@1
+  displayName: Generate Setup Inputs
+  inputs:
+    filename: '$(comspec)'
+    arguments: '/c "call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\Tools\VsDevCmd.bat" & msbuild $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\GenerateMsiInputs.msbuild /p:Configuration=$(BuildConfiguration) /t:GenerateMSIInputs"'
 
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
   displayName: Install Swix Plugin

--- a/build/EF6Tools-VS2017-Nightly.yaml
+++ b/build/EF6Tools-VS2017-Nightly.yaml
@@ -51,13 +51,6 @@ steps:
   inputs:
     signType: '$(SigningType)'
 
-- task: NuGetCommand@2
-  displayName: 'NuGet Restore MicroBuild Core'
-  inputs:
-    command: custom
-    feedsToUse: config
-    arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
-
 - task: MSBuild@1
   displayName: Sign Unlocalized and Localized Assemblies
   inputs:

--- a/build/EF6Tools-VS2019-Nightly-PR.yaml
+++ b/build/EF6Tools-VS2019-Nightly-PR.yaml
@@ -50,6 +50,20 @@ steps:
     configuration: '$(BuildConfiguration)'
     msbuildArguments: '/t:PostBuild -binaryLogger:logfile=$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\Localize.binlog'
 
+- task: NuGetCommand@2
+  displayName: 'NuGet Restore Setup Inputs Packages'
+  inputs:
+    command: custom
+    feedsToUse: config
+    externalFeedCredentials: 'OSSCG Feed - Microsoft approved OSS packages'
+    arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
+
+- task: BatchScript@1
+  displayName: 'Extract Setup Inputs Nuspecs'
+  inputs:
+    filename: '$(comspec)'
+    arguments: '/c "call "$(ProgramFiles)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" & msbuild $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\GenerateMsiInputs.msbuild /p:Configuration=$(BuildConfiguration) /t:ExtractNuspecs"'
+
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@4
   displayName: 'Install Swix Plugin'
 

--- a/build/EF6Tools-VS2019-Nightly-PR.yaml
+++ b/build/EF6Tools-VS2019-Nightly-PR.yaml
@@ -51,18 +51,12 @@ steps:
     msbuildArguments: '/t:PostBuild -binaryLogger:logfile=$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\Localize.binlog'
 
 - task: NuGetCommand@2
-  displayName: 'NuGet Restore Setup Inputs Packages'
+  displayName: 'NuGet Restore MicroBuild Core'
   inputs:
     command: custom
     feedsToUse: config
     externalFeedCredentials: 'OSSCG Feed - Microsoft approved OSS packages'
     arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
-
-- task: BatchScript@1
-  displayName: 'Extract Setup Inputs Nuspecs'
-  inputs:
-    filename: '$(comspec)'
-    arguments: '/c "call "$(ProgramFiles)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" & msbuild $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\GenerateMsiInputs.msbuild /p:Configuration=$(BuildConfiguration) /t:ExtractNuspecs"'
 
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@4
   displayName: 'Install Swix Plugin'

--- a/build/EF6Tools-VS2019-Nightly-PR.yaml
+++ b/build/EF6Tools-VS2019-Nightly-PR.yaml
@@ -50,14 +50,6 @@ steps:
     configuration: '$(BuildConfiguration)'
     msbuildArguments: '/t:PostBuild -binaryLogger:logfile=$(Build.SourcesDirectory)\bin\$(BuildConfiguration)\Localize.binlog'
 
-- task: NuGetCommand@2
-  displayName: 'NuGet Restore MicroBuild Core'
-  inputs:
-    command: custom
-    feedsToUse: config
-    externalFeedCredentials: 'OSSCG Feed - Microsoft approved OSS packages'
-    arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
-
 - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@4
   displayName: 'Install Swix Plugin'
 

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -98,7 +98,7 @@ extends:
             msbuildArguments: '/t:PostBuild'
 
         - task: NuGetCommand@2
-          displayName: 'NuGet Restore Setup Inputs Packages'
+          displayName: 'NuGet Restore MicroBuild Core'
           inputs:
             command: custom
             feedsToUse: config
@@ -111,12 +111,6 @@ extends:
             solution: 'build\sign.proj'
             configuration: '$(BuildConfiguration)'
             msbuildArguments: '/t:AfterBuild'
-
-        - task: BatchScript@1
-          displayName: 'Extract Setup Inputs Nuspecs'
-          inputs:
-            filename: '$(comspec)'
-            arguments: '/c "call "$(ProgramFiles)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" & msbuild $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\GenerateMsiInputs.msbuild /p:Configuration=$(BuildConfiguration) /t:ExtractNuspecs"'
 
         - task: MSBuild@1
           displayName: 'Restore VSIX project'

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -97,12 +97,26 @@ extends:
             configuration: '$(BuildConfiguration)'
             msbuildArguments: '/t:PostBuild'
 
+        - task: NuGetCommand@2
+          displayName: 'NuGet Restore Setup Inputs Packages'
+          inputs:
+            command: custom
+            feedsToUse: config
+            externalFeedCredentials: 'OSSCG Feed - Microsoft approved OSS packages'
+            arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
+
         - task: MSBuild@1
           displayName: 'Sign Unlocalized and Localized Assemblies'
           inputs:
             solution: 'build\sign.proj'
             configuration: '$(BuildConfiguration)'
             msbuildArguments: '/t:AfterBuild'
+
+        - task: BatchScript@1
+          displayName: 'Extract Setup Inputs Nuspecs'
+          inputs:
+            filename: '$(comspec)'
+            arguments: '/c "call "$(ProgramFiles)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" & msbuild $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\GenerateMsiInputs.msbuild /p:Configuration=$(BuildConfiguration) /t:ExtractNuspecs"'
 
         - task: MSBuild@1
           displayName: 'Restore VSIX project'

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -97,14 +97,6 @@ extends:
             configuration: '$(BuildConfiguration)'
             msbuildArguments: '/t:PostBuild'
 
-        - task: NuGetCommand@2
-          displayName: 'NuGet Restore MicroBuild Core'
-          inputs:
-            command: custom
-            feedsToUse: config
-            externalFeedCredentials: 'OSSCG Feed - Microsoft approved OSS packages'
-            arguments: 'restore $(Build.Repository.LocalPath)\src\EFTools\setup\GenerateMsiInputs\packages.config -SolutionDirectory $(MsiRuntimeInputsPath) -Verbosity Detailed -NonInteractive'
-
         - task: MSBuild@1
           displayName: 'Sign Unlocalized and Localized Assemblies'
           inputs:

--- a/build/sign.proj
+++ b/build/sign.proj
@@ -23,31 +23,11 @@
       <LocalizedEFToolsDLLs Include="$(RepositoryRootDirectory)bin\$(Configuration)\Microsoft.Data.Tools.Design.XmlCore.dll" />
       <LocalizedEFToolsDLLs Include="$(RepositoryRootDirectory)bin\$(Configuration)\Microsoft.VisualStudio.Data.Tools.Design.XmlCore.dll" />
       <LocalizedEFToolsDLLs Include="$(LocOutDir)\**\*.resources.dll" />
-
-      <!-- EntityFramework NuGet package contents shipped in the VSIX.
-           These packages contain DLLs with SHA1-only Microsoft Authenticode
-           signatures. Re-sign with SHA256 (Microsoft400) before the VSIX
-           build packages them. -->
-      <MsiInputDlls Include="$(RepositoryRootDirectory)bin\$(Configuration)\MsiRuntimeInputs\packages\**\*.dll" />
-      <MsiInputExes Include="$(RepositoryRootDirectory)bin\$(Configuration)\MsiRuntimeInputs\packages\**\*.exe" />
-      <MsiInputPs1s Include="$(RepositoryRootDirectory)bin\$(Configuration)\MsiRuntimeInputs\packages\**\*.ps1" />
     </ItemGroup>
     <ItemGroup>
       <FilesToSign Include="@(LocalizedEFToolsDLLs)">
         <Authenticode>Microsoft400</Authenticode>
         <StrongName>67</StrongName>
-      </FilesToSign>
-      <!-- Authenticode-only re-sign for NuGet package contents.
-           These assemblies already have valid strong names; only the
-           Authenticode signature needs upgrading from SHA1 to SHA256. -->
-      <FilesToSign Include="@(MsiInputDlls)">
-        <Authenticode>Microsoft400</Authenticode>
-      </FilesToSign>
-      <FilesToSign Include="@(MsiInputExes)">
-        <Authenticode>Microsoft400</Authenticode>
-      </FilesToSign>
-      <FilesToSign Include="@(MsiInputPs1s)">
-        <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
     </ItemGroup>
 

--- a/setup/wix/EFToolsWillowMsi.wixproj
+++ b/setup/wix/EFToolsWillowMsi.wixproj
@@ -48,6 +48,7 @@
     <Compile Include="Folders.wxs" />
     <Compile Include="EFToolsWillowMsi.wxs" />
     <Compile Include="Licenses.wxs" />
+    <Compile Include="NuGetPackages.wxs" />
     <Compile Include="ReferenceCounting.wxs" />
   </ItemGroup>
 

--- a/setup/wix/EFToolsWillowMsi.wxs
+++ b/setup/wix/EFToolsWillowMsi.wxs
@@ -15,6 +15,7 @@
 
     <Feature Id="EFTools_Singleton_MSI" Absent="allow" Display="2" Level="1">
       <ComponentGroupRef Id="CG_Licenses" />
+      <ComponentGroupRef Id="CG_NuGetPackageComponents" />
       <ComponentGroupRef Id="CG_ReferenceCounting" />
     </Feature>
     <WixVariable Id="WixUILicenseRtf" Value="eulas\enu\eula.rtf" />

--- a/setup/wix/Folders.wxs
+++ b/setup/wix/Folders.wxs
@@ -4,6 +4,7 @@
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFilesFolder">
         <Directory Id="INSTALLDIR" Name="Entity Framework Tools">
+          <Directory Id="EFT_NUGET_PKG_DIR" Name="NuGet Packages" />
         </Directory>
       </Directory>
     </Directory>

--- a/setup/wix/NuGetPackages.wxs
+++ b/setup/wix/NuGetPackages.wxs
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <?define NuGetLangs = de;es;fr;it;ja;ko;ru;zh-Hans;zh-Hant?>
+    <!--If a package version is added with a hyphen then it must also be included in the hyphen checks below.-->
+    <?define PackageVersions = $(var.EF5NuGetPackageVersion);$(var.EF6NuGetPackageVersion)?>
+    <DirectoryRef Id="EFT_NUGET_PKG_DIR">
+      <Component Id="Nuget_Repository_Registry_Key">
+        <RegistryValue Key="Software\NuGet\Repository" Name="EntityFrameworkVisualStudio$(var.ToolingVersionMajor)Tools" Root="HKLM" Type="string" Value="[EFT_NUGET_PKG_DIR]"/>
+      </Component>
+      <?foreach PackageVersion in $(var.PackageVersions)?>
+        <?if $(var.PackageVersion) = $(var.EF6NuGetPackageVersion)?>
+          <?define packageVersionId = $(var.EF6NuGetPackageWixId)?>
+        <?else?>
+          <?define packageVersionId = $(var.PackageVersion)?>
+        <?endif?>
+        <Directory Id="EntityFramework_$(var.packageVersionId)" Name="EntityFramework.$(var.PackageVersion)">
+          <Directory Id="content_$(var.packageVersionId)" Name="Content">
+          <?if $(var.PackageVersion) = $(var.EF6NuGetPackageVersion)?>
+            <Directory Id="content_net40_$(var.packageVersionId)" Name="net40">
+              <Component Id="App.config.transform_$(var.packageVersionId)">
+                <File Id="app.config.transform_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\Content\net40\App.config.transform"/>
+              </Component>
+              <Component Id="Web.config.transform_$(var.packageVersionId)">
+                <File Id="web.config.transform_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\Content\net40\Web.config.transform"/>
+              </Component>
+            </Directory>
+          <?else?>
+            <Component Id="App.config.transform_$(var.packageVersionId)">
+              <File Id="app.config.transform_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\Content\App.config.transform"/>
+            </Component>
+            <Component Id="Web.config.transform_$(var.packageVersionId)">
+              <File Id="web.config.transform_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\Content\Web.config.transform"/>
+            </Component>
+          <?endif?>
+          </Directory>
+          <Directory Id="tools_$(var.packageVersionId)" Name="tools">
+          <?if $(var.PackageVersion) = $(var.EF5NuGetPackageVersion)?>
+            <Component Id="about_EntityFramework.help.txt_$(var.packageVersionId)">
+              <File Id="about_EF.help.txt_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\about_EntityFramework.help.txt"/>
+            </Component>
+          <?else?>
+            <Component Id="about_EntityFramework.help.txt_$(var.packageVersionId)">
+              <File Id="about_EF.help.txt_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\about_EntityFramework6.help.txt"/>
+            </Component>
+          <?endif?>
+
+          <?if $(var.PackageVersion) = $(var.EF5NuGetPackageVersion)?>
+            <Component Id="EntityFramework.PowerShell.dll_$(var.packageVersionId)">
+              <File Id="EF.Powershell.dll_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\EntityFramework.PowerShell.dll"/>
+            </Component>
+            <Component Id="EntityFramework.PowerShell.Utility.dll_$(var.packageVersionId)">
+              <File Id="EF.Powershell.Utility.dll_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\EntityFramework.PowerShell.Utility.dll"/>
+            </Component>
+          <?endif?>
+            <Component Id="init.ps1_$(var.packageVersionId)">
+              <File Id="init.ps1_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\init.ps1"/>
+            </Component>
+            <Component Id="install.ps1_$(var.packageVersionId)">
+              <File Id="install.ps1_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\install.ps1"/>
+            </Component>
+            <?if $(var.PackageVersion) = $(var.EF5NuGetPackageVersion)?>
+              <Component Id="EntityFramework.PS3.psd1_$(var.packageVersionId)">
+                <File Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\EntityFramework.PS3.psd1"/>
+              </Component>
+              <Component Id="EntityFramework.psd1_$(var.packageVersionId)">
+                <File Id="EF.psd1_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\EntityFramework.psd1"/>
+              </Component>
+              <Component Id="EntityFramework.psm1_$(var.packageVersionId)">
+                <File Id="EF.psm1_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\EntityFramework.psm1"/>
+              </Component>
+              <Component Id="migrate.exe_$(var.packageVersionId)">
+                <File Id="migrate.exe_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\migrate.exe"/>
+              </Component>
+              <Component Id="Redirect.config_$(var.packageVersionId)">
+                <File Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\Redirect.config"/>
+              </Component>
+              <Component Id="Redirect.VS11.config_$(var.packageVersionId)">
+                <File Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\Redirect.VS11.config"/>
+              </Component>
+            <?else?>
+              <Component Id="EntityFramework.psd1_$(var.packageVersionId)">
+                <File Id="EF.psd1_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\EntityFramework6.psd1"/>
+              </Component>
+              <Component Id="EntityFramework.psm1_$(var.packageVersionId)">
+                <File Id="EF.psm1_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\tools\EntityFramework6.psm1"/>
+              </Component>
+            <?endif?>
+          </Directory>
+          <Directory Id="lib_$(var.packageVersionId)" Name="lib">
+            <Directory Id="net40_$(var.packageVersionId)" Name="net40">
+              <Component Id="entityframeworkdll_1_$(var.packageVersionId)">
+                <File Id="entityframeworkdll_1_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\lib\net40\EntityFramework.dll"/>
+              </Component>
+              <Component Id="EntityFramework.xml_$(var.packageVersionId)">
+                <File Id="EntityFramework.xml_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\lib\net40\EntityFramework.xml"/>
+              </Component>
+              <?if $(var.PackageVersion) != $(var.EF5NuGetPackageVersion)?>
+                <Component Id="EntityFramework.SqlServerProvider.dll_$(var.packageVersionId)">
+                  <File Id="EntityFramework.SqlServerProvider.dll_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\lib\net40\EntityFramework.SqlServer.dll"/>
+                </Component>
+                <Component Id="EntityFramework.SqlServerProvider.xml_$(var.packageVersionId)">
+                  <File Id="EntityFramework.SqlServerProvider.xml_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\lib\net40\EntityFramework.SqlServer.xml"/>
+                </Component>
+              <?endif?>
+            </Directory>
+            <Directory Id="net45_$(var.packageVersionId)" Name="net45">
+              <Component Id="entityframeworkdll_2_$(var.packageVersionId)">
+                <File Id="entityframeworkdll_2_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\lib\net45\EntityFramework.dll"/>
+              </Component>
+              <Component Id="entityframeworkxml_1_$(var.packageVersionId)">
+                <File Id="entityframeworkxml_1_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\lib\net45\EntityFramework.xml"/>
+              </Component>
+              <?if $(var.PackageVersion) != $(var.EF5NuGetPackageVersion)?>
+                <Component Id="EntityFramework.SqlServerProvider.dll_1_$(var.packageVersionId)">
+                  <File Id="EntityFramework.SqlServerProvider.dll_1_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\lib\net45\EntityFramework.SqlServer.dll"/>
+                </Component>
+                <Component Id="EntityFramework.SqlServerProvider.xml_1_$(var.packageVersionId)">
+                  <File Id="EntityFramework.SqlServerProvider.xml_1_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\lib\net45\EntityFramework.SqlServer.xml"/>
+                </Component>
+              <?endif?>
+            </Directory>
+          </Directory>
+          <Component Id="EntityFramework.$(var.packageVersionId).nuspec">
+            <File Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\EntityFramework.$(var.PackageVersion).nuspec"/>
+          </Component>
+        </Directory>
+        <Component>
+          <File Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.PackageVersion)\EntityFramework.$(var.PackageVersion).nupkg"/>
+        </Component>
+        <?undef packageVersionId?>
+      <?endforeach?>
+
+      <?if $(var.IncludeLocalizedArtifacts) = true ?>
+        <?foreach PackageVersion in $(var.PackageVersions)?>
+          <?if $(var.PackageVersion) = $(var.EF6NuGetPackageVersion)?>
+            <?define packageVersionId = $(var.EF6NuGetPackageWixId)?>
+            <?define locPackageVersionId = $(var.EF6NuGetLocPackageVersion)?>
+          <?else?>
+            <?define packageVersionId = $(var.PackageVersion)?>
+            <?define locPackageVersionId = $(var.PackageVersion)?>
+          <?endif?>
+      
+          <?foreach NuGetLang in $(var.NuGetLangs)?>
+            <!-- WIX Ids cannot have hyphens, so we need to handle zh langs differently -->
+            <?if $(var.NuGetLang) = zh-Hans?>
+              <?define safeLang = zhHans?>
+            <?elseif $(var.NuGetLang)= zh-Hant?>
+              <?define safeLang = zhHant?>
+            <?else?>
+              <?define safeLang = $(var.NuGetLang)?>
+            <?endif?>
+
+            <Directory Id="entityframework$(var.safeLang)_$(var.packageVersionId)" Name="EntityFramework.$(var.NuGetLang).$(var.locPackageVersionId)">
+              <Directory Id="lib_$(var.safeLang)_$(var.packageVersionId)" Name="lib">
+                <Directory Id="net40_$(var.safeLang)_$(var.packageVersionId)" Name="net40">
+                  <Directory Id="$(var.safeLang)_$(var.packageVersionId)" Name="$(var.NuGetLang)">
+                    <Component Id="entityframeworkresourcesdll_$(var.safeLang)_$(var.packageVersionId)">
+                      <File Id="entityframeworkresourcesdll_$(var.safeLang)_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.NuGetLang).$(var.locPackageVersionId)\lib\net40\$(var.NuGetLang)\EntityFramework.resources.dll"/>
+                    </Component>
+                    <Component Id="entityframeworkxml_$(var.safeLang)_$(var.packageVersionId)">
+                      <File Id="entityframeworkxml_$(var.safeLang)_$(var.packageVersionId)" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.NuGetLang).$(var.locPackageVersionId)\lib\net40\$(var.NuGetLang)\EntityFramework.xml"/>
+                    </Component>
+                  </Directory>
+                </Directory>
+                <Directory Id="net45_$(var.safeLang)_$(var.packageVersionId)" Name="net45">
+                  <Directory Id="$(var.safeLang)_$(var.packageVersionId)_1" Name="$(var.NuGetLang)">
+                    <Component Id="entityframeworkresourcesdll_$(var.safeLang)_$(var.packageVersionId)_1">
+                      <File Id="entityframeworkresourcesdll_$(var.safeLang)_$(var.packageVersionId)_1" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.NuGetLang).$(var.locPackageVersionId)\lib\net45\$(var.NuGetLang)\EntityFramework.resources.dll"/>
+                    </Component>
+                    <Component Id="entityframeworkxml_$(var.safeLang)_$(var.packageVersionId)_1">
+                      <File Id="entityframeworkxml_$(var.safeLang)_$(var.packageVersionId)_1" Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.NuGetLang).$(var.locPackageVersionId)\lib\net45\$(var.NuGetLang)\EntityFramework.xml"/>
+                    </Component>
+                  </Directory>
+                </Directory>
+              </Directory>
+              <Component Id="entityframework$(var.safeLang)$(var.packageVersionId)nuspec">
+                <File Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.NuGetLang).$(var.locPackageVersionId)\EntityFramework.$(var.NuGetLang).$(var.locPackageVersionId).nuspec"/>
+              </Component>
+            </Directory>
+            <Component Id="entityframework$(var.safeLang)$(var.packageVersionId)nupkg">
+              <File Source="$(var.MsiRuntimeInputsPackagesDir)\EntityFramework.$(var.NuGetLang).$(var.locPackageVersionId)\EntityFramework.$(var.NuGetLang).$(var.locPackageVersionId).nupkg"/>
+            </Component>
+            <?undef safeLang?>
+          <?endforeach NuGetLang in $(var.NuGetLangs)?>
+          <?undef packageVersionId?>
+          <?undef locPackageVersionId?>
+        <?endforeach PackageVersion in $(var.PackageVersions)?>
+      <?endif IncludeLocalizedArtifacts?>
+    </DirectoryRef>
+
+    <ComponentGroup Directory="EFT_NUGET_PKG_DIR" Id="CG_NuGetPackageComponents">
+      <ComponentRef Id="Nuget_Repository_Registry_Key"/>
+
+      <?foreach PackageVersion in $(var.PackageVersions)?>
+        <?if $(var.PackageVersion) = $(var.EF6NuGetPackageVersion)?>
+          <?define packageVersionId = $(var.EF6NuGetPackageWixId)?>
+        <?else?>
+          <?define packageVersionId = $(var.PackageVersion)?>
+        <?endif?>
+
+        <ComponentRef Id="App.config.transform_$(var.packageVersionId)"/>
+        <ComponentRef Id="Web.config.transform_$(var.packageVersionId)"/>
+        <ComponentRef Id="about_EntityFramework.help.txt_$(var.packageVersionId)"/>
+        <ComponentRef Id="EntityFramework.psd1_$(var.packageVersionId)"/>
+        <ComponentRef Id="EntityFramework.psm1_$(var.packageVersionId)"/>
+        <ComponentRef Id="init.ps1_$(var.packageVersionId)"/>
+        <ComponentRef Id="install.ps1_$(var.packageVersionId)"/>
+        <ComponentRef Id="entityframeworkdll_1_$(var.packageVersionId)"/>
+        <ComponentRef Id="EntityFramework.xml_$(var.packageVersionId)"/>
+        <ComponentRef Id="entityframeworkdll_2_$(var.packageVersionId)"/>
+        <ComponentRef Id="entityframeworkxml_1_$(var.packageVersionId)"/>
+        <ComponentRef Id="EntityFramework.$(var.packageVersionId).nupkg"/>
+        <ComponentRef Id="EntityFramework.$(var.packageVersionId).nuspec"/>
+
+        <?if $(var.PackageVersion) = $(var.EF5NuGetPackageVersion)?>
+          <ComponentRef Id="EntityFramework.PowerShell.dll_$(var.packageVersionId)"/>
+          <ComponentRef Id="EntityFramework.PowerShell.Utility.dll_$(var.packageVersionId)"/>
+          <ComponentRef Id="EntityFramework.PS3.psd1_$(var.packageVersionId)"/>
+          <ComponentRef Id="migrate.exe_$(var.packageVersionId)"/>
+          <ComponentRef Id="Redirect.config_$(var.packageVersionId)"/>
+          <ComponentRef Id="Redirect.VS11.config_$(var.packageVersionId)"/>
+        <?else?>
+          <ComponentRef Id="EntityFramework.SqlServerProvider.dll_$(var.packageVersionId)" />
+          <ComponentRef Id="EntityFramework.SqlServerProvider.xml_$(var.packageVersionId)" />
+          <ComponentRef Id="EntityFramework.SqlServerProvider.dll_1_$(var.packageVersionId)" />
+          <ComponentRef Id="EntityFramework.SqlServerProvider.xml_1_$(var.packageVersionId)" />
+        <?endif?>
+
+        <?if $(var.IncludeLocalizedArtifacts) = true?>
+          <?foreach NuGetLang in $(var.NuGetLangs)?>
+            <!-- WIX Ids cannot have hyphens, so we need to handle zh langs differently -->
+            <?if $(var.NuGetLang) = zh-Hans?>
+              <?define safeLang = zhHans?>
+            <?elseif $(var.NuGetLang)= zh-Hant?>
+              <?define safeLang = zhHant?>
+            <?else?>
+              <?define safeLang = $(var.NuGetLang)?>
+            <?endif?>
+
+            <ComponentRef Id="entityframeworkresourcesdll_$(var.safeLang)_$(var.packageVersionId)"/>
+            <ComponentRef Id="entityframeworkxml_$(var.safeLang)_$(var.packageVersionId)"/>
+            <ComponentRef Id="entityframeworkresourcesdll_$(var.safeLang)_$(var.packageVersionId)_1"/>
+            <ComponentRef Id="entityframeworkxml_$(var.safeLang)_$(var.packageVersionId)_1"/>
+            <ComponentRef Id="entityframework$(var.safeLang)$(var.packageVersionId)nupkg"/>
+            <ComponentRef Id="entityframework$(var.safeLang)$(var.packageVersionId)nuspec"/>
+
+            <?undef safeLang?>
+          <?endforeach NuGetLang in $(var.NuGetLangs)?>
+        <?endif IncludeLocalizedArtifacts?>
+        <?undef packageVersionId?>
+
+      <?endforeach PackageVersion in $(var.PackageVersions)?>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/src/EFTools/EntityDesign/EntityDesign.csproj
+++ b/src/EFTools/EntityDesign/EntityDesign.csproj
@@ -1021,7 +1021,7 @@
       <InTheBoxItemTemplateFiles Include="VisualStudio\InTheBoxItemTemplates\*.vstman" />
     </ItemGroup>
     <MakeDir Directories="@(InTheBoxItemTemplateFiles->'$(TargetItemTemplateFilesDir)\%(RecursiveDir)')" />
-    <RegexReplaceInFile Condition="'%(Extension)' == '.vstemplate'" InputFileName="%(InTheBoxItemTemplateFiles.Identity)" OutputFileName="@(InTheBoxItemTemplateFiles->'$(TargetItemTemplateFilesDir)\%(RecursiveDir)%(Filename)%(Extension)')" Patterns="EFPACKAGEVERSION;EFDESIGNERVERSIONTOKEN" Replacements="$(EF6NuGetPackageVersion);$(AssemblyVersion)" />
+    <RegexReplaceInFile Condition="'%(Extension)' == '.vstemplate'" InputFileName="%(InTheBoxItemTemplateFiles.Identity)" OutputFileName="@(InTheBoxItemTemplateFiles->'$(TargetItemTemplateFilesDir)\%(RecursiveDir)%(Filename)%(Extension)')" Patterns="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN;EFPACKAGEVERSION;EFDESIGNERVERSIONTOKEN" Replacements="EntityFrameworkVisualStudio17Tools;$(EF6NuGetPackageVersion);$(AssemblyVersion)" />
     <Copy Condition="'%(Extension)' != '.vstemplate'" SourceFiles="@(InTheBoxItemTemplateFiles)" DestinationFiles="@(InTheBoxItemTemplateFiles->'$(TargetItemTemplateFilesDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
   <Target Name="CreateTemplatesAndPackages" DependsOnTargets="UpdateTemplateVersion;PrepareTemplatesForSetup">

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1028/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1028/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1031/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1031/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1033/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1033/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1034/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1034/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1036/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1036/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1040/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1040/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1041/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1041/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1042/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1042/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1049/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/1049/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/2052/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CSharp/Data/2052/CFCSEF6/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1028/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1028/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1031/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1031/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1033/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1033/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1034/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1034/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1036/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1036/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1040/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1040/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1041/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1041/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1042/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1042/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1049/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/1049/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/2052/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/VisualBasic/Data/2052/CFVBEF6/CodeFirst_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -34,7 +34,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1028/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1028/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1031/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1031/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1033/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1033/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1034/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1034/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1036/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1036/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1040/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1040/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1041/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1041/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1042/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1042/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1049/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/1049/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/2052/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/CSharp/2052/CFCSWSEF6/CodeFirst_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1028/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1028/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1031/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1031/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1033/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1033/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1034/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1034/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1036/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1036/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1040/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1040/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1041/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1041/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1042/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1042/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1049/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/1049/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/2052/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/CodeFirst/Web/VisualBasic/2052/CFVBWSEF6/CodeFirst_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>OneEF CodeFirst</Name>
@@ -35,7 +35,7 @@
   </WizardExtension>
   
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1028/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1028/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 產生器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hant" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1028/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1028/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 產生器</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1031/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1031/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x-DbContext-Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.de" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1031/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1031/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x-DbContext-Generator</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1033/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1033/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1033/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1033/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext Generator</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1034/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1034/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 5.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.es" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1034/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1034/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 6.x</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1036/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1036/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 5.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.fr" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1036/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1036/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 6.x</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1040/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1040/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 5.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.it" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1040/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1040/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 6.x DbContext</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1041/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1041/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext ジェネレーター</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ja" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1041/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1041/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext ジェネレーター</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1042/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1042/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 생성기</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ko" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1042/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1042/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 생성기</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1049/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1049/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 5.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ru" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1049/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/1049/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 6.x DbContext</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/2052/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/2052/DbCtxCSEF5/DbContext_CS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 生成器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hans" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/2052/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/CSharp/Data/2052/DbCtxCSEF6/DbContext_CS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 生成器</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_CS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_CS_V5.0.vstemplate
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_CS_WS_V5.0.vstemplate
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_VB_V5.0.vstemplate
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF5/DbContext_VB_WS_V5.0.vstemplate
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_CS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_CS_V6.0.vstemplate
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_CS_WS_V6.0.vstemplate
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_VB_V6.0.vstemplate
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/EF6/DbContext_VB_WS_V6.0.vstemplate
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1028/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1028/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 產生器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hant" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1028/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1028/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 產生器</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1031/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1031/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x-DbContext-Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.de" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1031/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1031/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x-DbContext-Generator</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1033/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1033/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1033/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1033/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext Generator</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1034/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1034/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 5.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.es" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1034/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1034/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 6.x</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1036/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1036/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 5.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.fr" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1036/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1036/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 6.x</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1040/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1040/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 5.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.it" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1040/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1040/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 6.x DbContext</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1041/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1041/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext ジェネレーター</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ja" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1041/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1041/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext ジェネレーター</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1042/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1042/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 생성기</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ko" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1042/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1042/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 생성기</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1049/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1049/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 5.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ru" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1049/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/1049/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 6.x DbContext</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/2052/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/2052/DbCtxVBEF5/DbContext_VB_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 生成器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hans" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/2052/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/VisualBasic/Data/2052/DbCtxVBEF6/DbContext_VB_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 生成器</Name>
@@ -39,7 +39,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1028/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1028/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 產生器</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hant" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1028/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1028/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 產生器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1031/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1031/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x-DbContext-Generator</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.de" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1031/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1031/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x-DbContext-Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1033/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1033/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext Generator</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1033/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1033/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1034/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1034/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 5.x</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.es" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1034/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1034/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 6.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1036/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1036/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 5.x</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.fr" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1036/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1036/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 6.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1040/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1040/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 5.x DbContext</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.it" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1040/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1040/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 6.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1041/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1041/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext ジェネレーター</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ja" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1041/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1041/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext ジェネレーター</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1042/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1042/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 생성기</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ko" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1042/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1042/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 생성기</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1049/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1049/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 5.x DbContext</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ru" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1049/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/1049/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 6.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/2052/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/2052/DbCtxCSWSEF5/DbContext_CS_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 生成器</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hans" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/2052/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/CSharp/2052/DbCtxCSWSEF6/DbContext_CS_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 生成器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1028/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1028/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 產生器</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hant" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1028/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1028/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 產生器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hant" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1031/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1031/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x-DbContext-Generator</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.de" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1031/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1031/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x-DbContext-Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.de" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1033/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1033/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext Generator</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1033/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1033/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext Generator</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
     </packages>
   </WizardData>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1034/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1034/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 5.x</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.es" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1034/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1034/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generador de DbContext EF 6.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.es" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1036/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1036/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 5.x</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.fr" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1036/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1036/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Générateur de DbContext EF 6.x</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.fr" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1040/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1040/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 5.x DbContext</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.it" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1040/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1040/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Generatore di EF 6.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.it" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1041/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1041/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext ジェネレーター</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ja" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1041/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1041/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext ジェネレーター</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ja" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1042/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1042/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 생성기</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ko" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1042/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1042/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 생성기</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ko" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1049/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1049/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 5.x DbContext</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.ru" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1049/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/1049/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>Генератор EF 6.x DbContext</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.ru" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/2052/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/2052/DbCtxVBWSEF5/DbContext_VB_WS_V5.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 5.x DbContext 生成器</Name>
@@ -45,7 +45,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="5.0.0" />
       <package id="EntityFramework.zh-Hans" version="5.0.0" />
     </packages>

--- a/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/2052/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
+++ b/src/EFTools/EntityDesign/VisualStudio/InTheBoxItemTemplates/DBContext/Web/VisualBasic/2052/DbCtxVBWSEF6/DbContext_VB_WS_V6.0.vstemplate
@@ -1,4 +1,4 @@
-<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
+﻿<VSTemplate Version="3.0.0" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" Type="Item">
 
   <TemplateData>
     <Name>EF 6.x DbContext 生成器</Name>
@@ -42,7 +42,7 @@
   </WizardExtension>
 
   <WizardData>
-    <packages>
+    <packages repository="registry" keyName="NUGETEFTOOLSPACKAGESREGKEYNAMETOKEN" isPreunzipped="true">
       <package id="EntityFramework" version="EFPACKAGEVERSION" />
       <package id="EntityFramework.zh-Hans" version="EFPACKAGEVERSION" />
     </packages>

--- a/src/EFTools/setup/GenerateMsiInputs/packages.config
+++ b/src/EFTools/setup/GenerateMsiInputs/packages.config
@@ -1,17 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="5.0.0" />
-  <package id="EntityFramework" version="6.5.1" />
-  <package id="EntityFramework.de" version="6.2.0" />
-  <package id="EntityFramework.es" version="6.2.0" />
-  <package id="EntityFramework.fr" version="6.2.0" />
-  <package id="EntityFramework.it" version="6.2.0" />
-  <package id="EntityFramework.ja" version="6.2.0" />
-  <package id="EntityFramework.ko" version="6.2.0" />
-  <package id="EntityFramework.ru" version="6.2.0" />
-  <package id="EntityFramework.zh-Hans" version="6.2.0" />
-  <package id="EntityFramework.zh-Hant" version="6.2.0" />
-  <package id="EntityFramework.SqlServerCompact" version="6.5.1" />
-
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" />
 </packages>

--- a/src/EFTools/setup/GenerateMsiInputs/packages.config
+++ b/src/EFTools/setup/GenerateMsiInputs/packages.config
@@ -1,4 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" />
+  <package id="EntityFramework" version="5.0.0" />
+  <package id="EntityFramework.de" version="5.0.0" />
+  <package id="EntityFramework.es" version="5.0.0" />
+  <package id="EntityFramework.fr" version="5.0.0" />
+  <package id="EntityFramework.it" version="5.0.0" />
+  <package id="EntityFramework.ja" version="5.0.0" />
+  <package id="EntityFramework.ko" version="5.0.0" />
+  <package id="EntityFramework.ru" version="5.0.0" />
+  <package id="EntityFramework.zh-Hans" version="5.0.0" />
+  <package id="EntityFramework.zh-Hant" version="5.0.0" />
+  <package id="EntityFramework" version="6.5.1" />
+  <package id="EntityFramework.de" version="6.2.0" />
+  <package id="EntityFramework.es" version="6.2.0" />
+  <package id="EntityFramework.fr" version="6.2.0" />
+  <package id="EntityFramework.it" version="6.2.0" />
+  <package id="EntityFramework.ja" version="6.2.0" />
+  <package id="EntityFramework.ko" version="6.2.0" />
+  <package id="EntityFramework.ru" version="6.2.0" />
+  <package id="EntityFramework.zh-Hans" version="6.2.0" />
+  <package id="EntityFramework.zh-Hant" version="6.2.0" />
+  <package id="EntityFramework.SqlServerCompact" version="6.5.1" />
+
+  <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" />	
 </packages>


### PR DESCRIPTION
Reverts PRs #86, #87, #88, and #89 to restore the repo to its pre-#86 state.

These PRs attempted to remove the MSI offline NuGet cache and fix signing compliance, but caused cascading issues:

#86 removed the MSI NuGet package cache (NuGetPackages.wxs), registry key, packages.config entries, and pipeline steps
#87 had to restore MicroBuild.Core NuGet restore that #86 broke (MSB4019 build failure)
#88 had to restore EF packages that the VSIX needs at runtime (SWIX1108 build failure) and added SHA256 re-signing workaround
#89 had to fix 132 vstemplate files that referenced the deleted registry key (template wizard failure)
After all 4 PRs, item templates still fail with "Unable to find version '6.2.0' of package 'EntityFramework'" because the offline NuGet cache and registry key are gone.

What this revert restores
setup/wix/NuGetPackages.wxs — the WiX component that creates the offline NuGet package cache and HKLM\Software\NuGet\Repository registry key
packages.config — all 22 EntityFramework package entries
All 132 vstemplate files — restored repository="registry" attributes
Pipeline steps for NuGet restore and nuspec extraction
Removes the SHA256 re-signing workaround from sign.proj