### PR TITLE
Re-sign EntityFramework NuGet package contents with SHA256 (Microsoft400)

### DIFF
--- a/build/sign.proj
+++ b/build/sign.proj
@@ -23,11 +23,32 @@
       <LocalizedEFToolsDLLs Include="$(RepositoryRootDirectory)bin\$(Configuration)\Microsoft.Data.Tools.Design.XmlCore.dll" />
       <LocalizedEFToolsDLLs Include="$(RepositoryRootDirectory)bin\$(Configuration)\Microsoft.VisualStudio.Data.Tools.Design.XmlCore.dll" />
       <LocalizedEFToolsDLLs Include="$(LocOutDir)\**\*.resources.dll" />
+
+      <!-- EntityFramework NuGet package contents shipped in the VSIX and MSI.
+           Packages restored from nuget.org (EF 5.0.0, EF 6.2.0 locales) carry
+           SHA1-only Authenticode signatures. Re-sign with SHA256 (Microsoft400)
+           to meet VS signing compliance requirements. MicroBuild dual-signs,
+           preserving the original SHA1 signature and strong name. -->
+      <NuGetPackageDlls Include="$(RepositoryRootDirectory)bin\$(Configuration)\MsiRuntimeInputs\packages\**\*.dll" />
+      <NuGetPackageExes Include="$(RepositoryRootDirectory)bin\$(Configuration)\MsiRuntimeInputs\packages\**\*.exe" />
+      <NuGetPackagePs1s Include="$(RepositoryRootDirectory)bin\$(Configuration)\MsiRuntimeInputs\packages\**\*.ps1" />
     </ItemGroup>
     <ItemGroup>
       <FilesToSign Include="@(LocalizedEFToolsDLLs)">
         <Authenticode>Microsoft400</Authenticode>
         <StrongName>67</StrongName>
+      </FilesToSign>
+      <!-- Authenticode-only re-sign for NuGet package contents.
+           These assemblies already have valid strong names; only the
+           Authenticode signature needs upgrading from SHA1 to SHA256. -->
+      <FilesToSign Include="@(NuGetPackageDlls)">
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="@(NuGetPackageExes)">
+        <Authenticode>Microsoft400</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="@(NuGetPackagePs1s)">
+        <Authenticode>Microsoft400</Authenticode>
       </FilesToSign>
     </ItemGroup>
 


### PR DESCRIPTION
Summary
Add SHA256 re-signing for EntityFramework NuGet package DLLs, EXEs, and PS1 files shipped in the VSIX and MSI.

Problem
The EntityFramework packages restored from nuget.org contain DLLs with SHA1-only Authenticode signatures:

EntityFramework 5.0.0 — signed in 2013, root: Microsoft Root Certificate Authority (SHA1)
EntityFramework.{locale} 6.2.0 (de, es, fr, it, ja, ko, ru, zh-Hans, zh-Hant) — signed in 2018, root: Microsoft Root Certificate Authority (SHA1)
The source build systems for these packages no longer exist — EF 5.0.0 predates this repo, and the localization infrastructure for the 6.2.0 locale satellites was part of a legacy build that was not migrated to the current Arcade-based repo (dotnet/ef6). These packages cannot be republished with SHA256 signatures at source.

EntityFramework 6.5.1 and EntityFramework.SqlServerCompact 6.5.1 are already SHA256-signed (built by dotnet/ef6 with Arcade + MicroBuild).

Fix
Add glob patterns in build/sign.proj to re-sign all files from MsiRuntimeInputs\packages\ with Microsoft400:

**\*.dll — EF runtime DLLs and locale satellite assemblies
**\*.exe — ef6.exe CLI tool
**\*.ps1 — NuGet package PowerShell scripts (init.ps1, install.ps1, EntityFramework.psm1)
MicroBuild dual-signs these files — adding a SHA256 Authenticode signature while preserving the existing SHA1 signature and strong name. The pipeline already restores NuGet packages (step 7) before [sign.proj](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) runs (step 8), and the VSIX (step 11) and MSI (step 13) builds consume the signed copies.