### PR TITLE
NGEN EntityDesigner.dll at Pri3

### DIFF
--- a/setup/swix/files.swr
+++ b/setup/swix/files.swr
@@ -15,7 +15,7 @@ folder "InstallDir:\Common7\IDE"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.BootstrapPackage.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.DatabaseGeneration.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.dll"
-  file source="$(OutputPath)\Microsoft.Data.Entity.Design.EntityDesigner.dll"
+  file source="$(OutputPath)\Microsoft.Data.Entity.Design.EntityDesigner.dll" vs.file.ngen=yes vs.file.ngenPriority=3
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.Model.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.Package.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.VersioningFacade.dll"


### PR DESCRIPTION
Add `vs.file.ngen=yes vs.file.ngenPriority=3` to `Microsoft.Data.Entity.Design.EntityDesigner.dll` in `setup/swix/files.swr`.

This assembly is JIT'd on the main thread during WinForms designer toolbox scenarios (toolbox refresh when opening a designer with an EF model). NGEN at Pri3 eliminates the JIT cost for warm runs.