### PR TITLE
NGen Entity.Design and Data.Tools.Design.XmlCore (priority 3)

### DIFF
--- a/setup/swix/files.swr
+++ b/setup/swix/files.swr
@@ -14,13 +14,13 @@ folder "InstallDir:\Common7\IDE"
   file source="$(OutputPath)\MsiRuntimeInputs\packages\EntityFramework.SqlServerCompact.$(EF6NuGetPackageVersion)\lib\net45\EntityFramework.SqlServerCompact.dll" vs.file.ngen=no
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.BootstrapPackage.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.DatabaseGeneration.dll"
-  file source="$(OutputPath)\Microsoft.Data.Entity.Design.dll"
+  file source="$(OutputPath)\Microsoft.Data.Entity.Design.dll" vs.file.ngen=yes vs.file.ngenPriority=3
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.EntityDesigner.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.Model.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.Package.dll"
   file source="$(OutputPath)\Microsoft.Data.Entity.Design.VersioningFacade.dll"
   file source="$(OutputPath)\Microsoft.Data.Tools.Design.XmlCore.dll"
-  file source="$(OutputPath)\Microsoft.VisualStudio.Data.Tools.Design.XmlCore.dll"
+  file source="$(OutputPath)\Microsoft.VisualStudio.Data.Tools.Design.XmlCore.dll" vs.file.ngen=yes vs.file.ngenPriority=3
   folder "CommonExtensions\Microsoft\EFTools"
     file source="$(OutputPath)\PkgDefData\Microsoft.Data.Entity.Design.BootstrapPackage.pkgdef"
     file source="$(OutputPath)\PkgDefData\Microsoft.Data.Entity.Design.Package.pkgdef"


### PR DESCRIPTION
Microsoft.Data.Entity.Design and Microsoft.VisualStudio.Data.Tools.Design.XmlCore load JIT-only today with no native image. NGEN both at priority 3 so the EF6 / EDMX designer pays no JIT cost when it first opens.

Both already ship to Common7\IDE (the app base), so they bind by name in the default load context and use the native image — no binding path, no LoadFrom.

Follows the same NGEN pattern used in VS repo PR 741831.

*Cowritten with Copilot*