### PR TITLE
Opt out of IntelliSense-ready deferral for the EF entity designer editor factory

### DIFF
--- a/src/EFTools/EntityDesignPackage/GeneratedCode/Package.cs
+++ b/src/EFTools/EntityDesignPackage/GeneratedCode/Package.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Entity.Design.Package
 					"vs.edm.common.inheritancerelationships", 
 					"@InheritanceToolToolboxBitmap;Microsoft.Data.Entity.Design.EntityDesigner.dll", 
 					0xff00ff)]
-	[VSShell::ProvideEditorFactory(typeof(MicrosoftDataEntityDesignEditorFactory), 103, TrustLevel = VSShellInterop::__VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted)]
+	[VSShell::ProvideEditorFactory(typeof(MicrosoftDataEntityDesignEditorFactory), 103, deferUntilIntellisenseIsReady: false, TrustLevel = VSShellInterop::__VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted)]
 	[VSShell::ProvideEditorExtension(typeof(MicrosoftDataEntityDesignEditorFactory), "." + Constants.DesignerFileExtension, 50)]
 	[DslShell::ProvideRelatedFile("." + Constants.DesignerFileExtension, Constants.DefaultDiagramExtension,
 		ProjectSystem = DslShell::ProvideRelatedFileAttribute.CSharpProjectGuid,

--- a/src/EFTools/EntityDesignPackage/PkgDefData/Microsoft.Data.Entity.Design.Package.pkgdef
+++ b/src/EFTools/EntityDesignPackage/PkgDefData/Microsoft.Data.Entity.Design.Package.pkgdef
@@ -9,6 +9,7 @@
 "EditorTrustLevel"=dword:00000001
 "Package"="{8889e051-b7f9-4781-bb33-2a36a9bdb3a5}"
 "CommonPhysicalViewAttributes"=dword:00000002
+"DeferUntilIntellisenseIsReady"=dword:00000000
 
 [$RootKey$\Editors\{c99aea30-8e36-4515-b76f-496f5a48a6aa}\Extensions]
 "edmx"=dword:0000003d


### PR DESCRIPTION
`deferUntilIntellisenseIsReady` defaults to `true` for editor factories, so the EF entity designer waits for IntelliSense readiness before opening even though it doesn't use the DTE CodeModel — its code generation is delegated to a single-file generator, not the code model. This sets `deferUntilIntellisenseIsReady: false` on the `MicrosoftDataEntityDesignEditorFactory` registration in the generated `Package.cs` so it opens without the wait.

Part of a cross-repo sweep flipping non-CodeModel editor factories to opt out of the deferral.

*Cowritten with Copilot (Claude Opus 4.8)*